### PR TITLE
Fix QuickSwitch Shortcut to not overwrite Settings Shortcut on non-Mac devices

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -345,7 +345,7 @@ const _templateFactory = intl => [
       },
       {
         label: intl.formatMessage(menuItems.openQuickSwitch),
-        accelerator: 'CmdOrCtrl+P',
+        accelerator: 'CmdOrCtrl+S',
         click() {
           window.ferdi.features.quickSwitch.state.isModalVisible = true;
         },
@@ -549,7 +549,7 @@ const _titleBarTemplateFactory = intl => [
       },
       {
         label: intl.formatMessage(menuItems.openQuickSwitch),
-        accelerator: 'CmdOrCtrl+P',
+        accelerator: 'CmdOrCtrl+S',
         click() {
           window.ferdi.features.quickSwitch.state.isModalVisible = true;
         },
@@ -804,7 +804,7 @@ export default class FranzMenu {
         },
         {
           label: intl.formatMessage(menuItems.settings),
-          accelerator: 'CmdOrCtrl+,',
+          accelerator: 'CmdOrCtrl+P',
           click: () => {
             this.actions.ui.openSettings({ path: 'app' });
           },

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -804,7 +804,7 @@ export default class FranzMenu {
         },
         {
           label: intl.formatMessage(menuItems.settings),
-          accelerator: 'CmdOrCtrl+P',
+          accelerator: 'CmdOrCtrl+,',
           click: () => {
             this.actions.ui.openSettings({ path: 'app' });
           },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
From #85 
### Description
<!--- Describe your changes in detail -->
In the File there is "Settings" with the description "CTRL+P" but it appear that the [Quick switch feature (see commit)](https://github.com/getferdi/ferdi/commit/1d41b849cb7840a1611d34f20bfe636fc8b903dc) is using this shortcut instead. And when putting the mouse over the cog in the bottom left corner: we can see a bubble saying "Settings (CTRL+,)" with no other key to show what to press on and using the shortcut.

Maybe we can use CTRL+S instead?
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For fixing the app
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
See the comment below
### Screenshots (if appropriate):
![wrongshortcut](https://user-images.githubusercontent.com/49844464/65839600-901ccd80-e2dc-11e9-9cf4-67c6276e708a.png)
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
