### PR TITLE
Better handling for user data path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,11 @@ import windowStateKeeper from 'electron-window-state';
 
 // Set app directory before loading user modules
 if (isDevMode) {
-  app.setPath('userData', path.join(app.getPath('appData'), 'FranzDev'));
+  app.setPath('userData', path.join(app.getPath('appData'), app.getName() + 'Dev'));
+} else if (process.env.FERDI_USERDATA_DIR != null) {
+  app.setPath('userData', process.env.FERDI_USERDATA_DIR)
+} else if (process.env.PORTABLE_EXECUTABLE_DIR != null) {
+  app.setPath('userData', path.join(process.env.PORTABLE_EXECUTABLE_DIR, app.getName()));
 }
 
 /* eslint-disable import/first */


### PR DESCRIPTION
For https://github.com/getferdi/ferdi/issues/87.  
Can be defined via the `FERDI_USERDATA_DIR` env variable.
For portable apps, we use the `PORTABLE_EXECUTABLE_DIR ` env variable as the base path.