### PR TITLE
Change menu bar logic to be hidden by default when autohide is enabled

### DIFF
--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -47,9 +47,11 @@ export default class SettingsStore extends Store {
 
     reaction(
       () => this.all.app.autohideMenuBar,
-      () => remote.getCurrentWindow().setAutoHideMenuBar(
-        this.all.app.autohideMenuBar,
-      ),
+      () => {
+        const currentWindow = remote.getCurrentWindow();
+        currentWindow.setMenuBarVisibility(!this.all.app.autohideMenuBar);
+        currentWindow.setAutoHideMenuBar(this.all.app.autohideMenuBar);
+      },
     );
 
     reaction(


### PR DESCRIPTION
### Description
When the user enables the `Auto-hide menu bar` option, we can probably presume that they likely won't use the menu bar on each startup/immediately after changing the option. This PR changes the `Auto-hide menu bar` handler to also set the visibility state of the menu bar to the inverse of `Auto-hide menu bar` (auto-hide on => hidden by default, auto-hide off => shown by default), which still allows the user to show the menu bar by pressing Alt.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
