### PR TITLE
Update electron to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9878,20 +9878,20 @@
       }
     },
     "electron-rebuild": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.8.8.tgz",
-      "integrity": "sha512-9a/VGbVpTJcuBaZa8yMcegqJ5flGPYDo363AxXDMxY4ZHPtFMLedGzQW9+720SIS1cvjX8B0zC+vMHO75ncOiA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.10.0.tgz",
+      "integrity": "sha512-n10i30GJg7JH8yZL3ZY3x80YtKmSYuuN8cl+3Feljm+sQDU4rUW1jbnYGu0eUHlK3kPOiNWPtW7srGcwZ9p1zQ==",
       "dev": true,
       "requires": {
         "colors": "^1.3.3",
         "debug": "^4.1.1",
         "detect-libc": "^1.0.3",
-        "fs-extra": "^7.0.1",
+        "fs-extra": "^8.1.0",
         "node-abi": "^2.11.0",
         "node-gyp": "^6.0.1",
         "ora": "^3.4.0",
         "spawn-rx": "^3.0.0",
-        "yargs": "^13.2.4"
+        "yargs": "^14.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -9917,6 +9917,17 @@
           "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
           "dev": true
         },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "get-caller-file": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -9934,9 +9945,9 @@
           }
         },
         "node-gyp": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.0.1.tgz",
-          "integrity": "sha512-udHG4hGe3Ji97AYJbJhaRwuSOuQO7KHnE4ZPH3Sox3tjRZ+bkBsDvfZ7eYA1qwD8eLWr//193x806ss3HFTPRw==",
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-6.1.0.tgz",
+          "integrity": "sha512-h4A2zDlOujeeaaTx06r4Vy+8MZ1679lU+wbCKDS4ZtvY2A37DESo37oejIw0mtmR3+rvNwts5B6Kpt1KrNYdNw==",
           "dev": true,
           "requires": {
             "env-paths": "^2.2.0",
@@ -10015,12 +10026,13 @@
           }
         },
         "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "version": "14.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
+          "integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
           "dev": true,
           "requires": {
             "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
             "find-up": "^3.0.0",
             "get-caller-file": "^2.0.1",
             "require-directory": "^2.1.1",
@@ -10029,13 +10041,13 @@
             "string-width": "^3.0.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
+            "yargs-parser": "^15.0.0"
           }
         },
         "yargs-parser": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "version": "15.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
+          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -19134,9 +19146,9 @@
       }
     },
     "node-abi": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
-      "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.15.0.tgz",
+      "integrity": "sha512-FeLpTS0F39U7hHZU1srAK4Vx+5AHNVOTP+hxBNQknR/54laTHSFIJkDWDqiquY1LeLUgTfPN7sLPhMubx0PLAg==",
       "dev": true,
       "requires": {
         "semver": "^5.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2592,9 +2592,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.7.2.tgz",
-      "integrity": "sha512-LSE4LZGMjGS9TloDx0yO44D2UTbaeKRk+QjlhWLiQlikV6J4spgDCjb6z4YIcqmPAwNzlNCnWF4dubytwI+ATA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.7.6.tgz",
+      "integrity": "sha512-zlNikt6ziVLNcm4lly1L4y62fJd/eYpEBjF5DiV/VAQq2vdPjH4sbUphXt9upmHz86lAhAj8g9lTnWrxJ/KBZw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -6741,9 +6741,9 @@
       "dev": true
     },
     "boolean": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.0.tgz",
-      "integrity": "sha512-OElxJ1lUSinuoUnkpOgLmxp0DC4ytEhODEL6QJU0NpxE/mI4rUSh8h1P1Wkvfi3xQEBcxXR2gBIPNYNuaFcAbQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA==",
       "dev": true,
       "optional": true
     },
@@ -9624,9 +9624,9 @@
       "dev": true
     },
     "electron": {
-      "version": "7.1.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-7.1.6.tgz",
-      "integrity": "sha512-0QSxQYYzSrBRbctKgAWS79k/I+vm95I7bz/zTuF0Qv4PvTtQf5hK21q6wtyKVPPJFFXnmSyvfQ2ce6iktfgK8g==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-8.0.0.tgz",
+      "integrity": "sha512-vBXUKRqTUq0jv1upvISdvScDDH3uCPwXj4eA5BeR3UDbJp2hOhq7eJxwjIQbfLQql98aYz4X6pSlzBnhfyQqHA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -13471,32 +13471,32 @@
       }
     },
     "global-agent": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.7.tgz",
-      "integrity": "sha512-ooK7eqGYZku+LgnbfH/Iv0RJ74XfhrBZDlke1QSzcBt0bw1PmJcnRADPAQuFE+R45pKKDTynAr25SBasY2kvow==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
+      "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
-        "core-js": "^3.4.1",
+        "core-js": "^3.6.4",
         "es6-error": "^4.1.1",
-        "matcher": "^2.0.0",
-        "roarr": "^2.14.5",
-        "semver": "^6.3.0",
+        "matcher": "^2.1.0",
+        "roarr": "^2.15.2",
+        "semver": "^7.1.2",
         "serialize-error": "^5.0.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
-          "integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw==",
+          "version": "3.6.4",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
           "dev": true,
           "optional": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
           "dev": true,
           "optional": true
         }
@@ -22994,15 +22994,15 @@
       "integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
     },
     "roarr": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.14.6.tgz",
-      "integrity": "sha512-qjbw0BEesKA+3XFBPt+KVe1PC/Z6ShfJ4wPlx2XifqH5h2Lj8/KQT5XJTsy3n1Es5kai+BwKALaECW3F70B1cg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
+      "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
       "dev": true,
       "optional": true,
       "requires": {
         "boolean": "^3.0.0",
         "detect-node": "^2.0.4",
-        "globalthis": "^1.0.0",
+        "globalthis": "^1.0.1",
         "json-stringify-safe": "^5.0.1",
         "semver-compare": "^1.0.0",
         "sprintf-js": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "electron": "8.0.0",
     "electron-builder": "21.2.0",
     "electron-notarize": "0.2.1",
-    "electron-rebuild": "1.8.8",
+    "electron-rebuild": "1.10.0",
     "eslint": "5.10.0",
     "eslint-config-airbnb": "17.1.0",
     "eslint-loader": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "cross-env": "^5.0.5",
     "cz-conventional-changelog": "2.1.0",
     "dotenv": "^4.0.0",
-    "electron": "7.1.6",
+    "electron": "8.0.0",
     "electron-builder": "21.2.0",
     "electron-notarize": "0.2.1",
     "electron-rebuild": "1.8.8",


### PR DESCRIPTION
### Fixes https://github.com/getferdi/ferdi/issues/369

If the host machine runs electron 8 currently ferdi stops working due to: 

```
Uncaught Error: Module did not self register.
```

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

Updates electron to 8.0.0 and electron-builder to 1.10.0 so that it also fixes:

```
An unhandled error occurred inside electron-rebuild
Could not detect abi for version 8.0.0 and runtime electron.  Updating "node-abi" might help solve this issue if it is a new release of electron
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
