### PR TITLE
Remove deprecated setLayoutZoomLevelLimits()

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -52,7 +52,6 @@ smoothScroll.polyfill();
 
 // Basic electron Setup
 webFrame.setVisualZoomLevelLimits(1, 1);
-webFrame.setLayoutZoomLevelLimits(0, 0);
 
 window.addEventListener('load', () => {
   const serverApi = new ServerApi();


### PR DESCRIPTION
### Description
Support for setLayoutZoomLevelLimits() is being removed from Chromium, deprecated in Electron 8.x, removed in 9.x. More info [here](https://www.electronjs.org/docs/api/breaking-changes#webframesetlayoutzoomlevellimits).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
