### PR TITLE
Fix uncaught error on injectCSS that does not exist

### DIFF
--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -67,9 +67,9 @@ class RecipeWebview {
    *                          be an absolute path to the file
    */
   injectCSS(...files) {
-    files.forEach((file) => {
-      if (fs.existsSync(file)) {
-        const data = fs.readFileSync(file);
+    files.forEach(async (file) => {
+      if (await fs.exists(file)) {
+        const data = await fs.readFile(file);
         const styles = document.createElement('style');
         styles.innerHTML = data.toString();
 

--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -68,13 +68,15 @@ class RecipeWebview {
    */
   injectCSS(...files) {
     files.forEach((file) => {
-      const data = fs.readFileSync(file);
-      const styles = document.createElement('style');
-      styles.innerHTML = data.toString();
+      if (fs.existsSync(file)) {
+        const data = fs.readFileSync(file);
+        const styles = document.createElement('style');
+        styles.innerHTML = data.toString();
 
-      document.querySelector('head').appendChild(styles);
+        document.querySelector('head').appendChild(styles);
 
-      debug('Append styles', styles);
+        debug('Append styles', styles);
+      }
     });
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Reading https://github.com/getferdi/ferdi/issues/349#issuecomment-590059031, I decided to go and add the `fs.existsSync` check before doing the previously problematic `fs.readFileSync`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
