### PR TITLE
Add custom dark mode handler support

### DIFF
--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -18,6 +18,7 @@ class RecipeWebview {
   }
 
   loopFunc = () => null;
+
   darkModeHandler = false;
 
   /**
@@ -81,8 +82,8 @@ class RecipeWebview {
 
   /**
    * Set a custom handler for turning on and off dark mode
-   * 
-   * @param {function} handler 
+   *
+   * @param {function} handler
    */
   handleDarkMode(handler) {
     this.darkModeHandler = handler;

--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -18,6 +18,7 @@ class RecipeWebview {
   }
 
   loopFunc = () => null;
+  darkModeHandler = false;
 
   /**
    * Initialize the loop
@@ -76,6 +77,15 @@ class RecipeWebview {
 
       debug('Append styles', styles);
     });
+  }
+
+  /**
+   * Set a custom handler for turning on and off dark mode
+   * 
+   * @param {function} handler 
+   */
+  handleDarkMode(handler) {
+    this.darkModeHandler = handler;
   }
 
   onNotify(fn) {

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -52,6 +52,7 @@ class RecipeController {
   universalDarkModeInjected = false;
 
   recipe = null;
+
   hasUpdatedBeforeRecipeLoaded = false;
 
   constructor() {

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -51,6 +51,9 @@ class RecipeController {
 
   universalDarkModeInjected = false;
 
+  recipe = null;
+  hasUpdatedBeforeRecipeLoaded = false;
+
   constructor() {
     this.initialize();
   }
@@ -82,11 +85,15 @@ class RecipeController {
     // Delete module from cache
     delete require.cache[require.resolve(modulePath)];
     try {
+      this.recipe = new RecipeWebview();
       // eslint-disable-next-line
-      require(modulePath)(new RecipeWebview(), {...config, recipe,});
+      require(modulePath)(this.recipe, {...config, recipe,});
       debug('Initialize Recipe', config, recipe);
 
       this.settings.service = Object.assign(config, { recipe });
+
+      // Make sure to update the WebView, otherwise the custom darkmode handler may not be used
+      this.update();
     } catch (err) {
       console.error('Recipe initialization failed', err);
     }
@@ -151,12 +158,25 @@ class RecipeController {
       }
     }
 
+    if (!this.recipe) {
+      this.hasUpdatedBeforeRecipeLoaded = true;
+    }
+
     console.log(
       'Darkmode enabled?',
       this.settings.service.isDarkModeEnabled,
       'Dark theme active?',
       this.settings.app.isDarkThemeActive,
     );
+
+    const handlerConfig = {
+      removeDarkModeStyle,
+      disableDarkMode,
+      enableDarkMode,
+      injectDarkModeStyle: () => injectDarkModeStyle(this.settings.service.recipe.path),
+      isDarkModeStyleInjected,
+    };
+
     if (this.settings.service.isDarkModeEnabled && this.settings.app.isDarkThemeActive !== false) {
       debug('Enable dark mode');
 
@@ -166,7 +186,19 @@ class RecipeController {
 
       console.log('darkmode.css exists? ', darkModeExists ? 'Yes' : 'No');
 
-      if (darkModeExists) {
+      // Check if recipe has a custom dark mode handler
+      if (this.recipe && this.recipe.darkModeHandler) {
+        console.log('Using custom dark mode handler');
+
+        // Remove other dark mode styles if they were already loaded
+        if (this.hasUpdatedBeforeRecipeLoaded) {
+          this.hasUpdatedBeforeRecipeLoaded = false;
+          removeDarkModeStyle();
+          disableDarkMode();
+        }
+
+        this.recipe.darkModeHandler(true, handlerConfig);
+      } else if (darkModeExists) {
         console.log('Injecting darkmode.css');
         injectDarkModeStyle(this.settings.service.recipe.path);
 
@@ -186,7 +218,16 @@ class RecipeController {
       debug('Remove dark mode');
       console.log('DarkMode disabled - removing remaining styles');
 
-      if (isDarkModeStyleInjected()) {
+      if (this.recipe && this.recipe.darkModeHandler) {
+        // Remove other dark mode styles if they were already loaded
+        if (this.hasUpdatedBeforeRecipeLoaded) {
+          this.hasUpdatedBeforeRecipeLoaded = false;
+          removeDarkModeStyle();
+          disableDarkMode();
+        }
+
+        this.recipe.darkModeHandler(false, handlerConfig);
+      } else if (isDarkModeStyleInjected()) {
         console.log('Removing injected darkmode.css');
         removeDarkModeStyle();
       } else {


### PR DESCRIPTION
### Description
Ferdi already supports adding a `darkmode.css` to a recipe that will automatically get injected into the page when dark mode gets activated.
Some services (like Reddit or YouTube) already ship with their own dark mode though, which cannot currently be automatically be switched on or off based on Ferdi's dark mode status.

This PR will will fix this problem by adding support for recipes to define a custom "dark mode handler" script that can handle the actions needed to turn the service's build-in dark mode on and off.

Demo of this in action:
![custom-darkmode-handler](https://user-images.githubusercontent.com/10333196/76141994-85bfe600-6069-11ea-838f-c42c162b9d81.gif)

The recipe automatically flips the "Night Mode" switch when Ferdi's dark mode gets activated.

The definition of this handler function is in each recipe's `webview.js` and could look like this (example for Reddit):
```JavaScript
// webview.js
module.exports = (Ferdi) => {
  // ..., other code like notification handler is here

  Ferdi.handleDarkMode((isEnabled, config) => {
    // Open dropdown menu if not already open
    const menu = document.querySelector('#USER_DROPDOWN_ID');
    if (menu.getAttribute('aria-expanded') === 'false') {
      menu.click();
    }

    setTimeout(() => {
      // Check if service is already in right mode
      const btn = document.querySelector('[role=menu] button button');
      const checked = btn.getAttribute('aria-checked') === 'true';
  
      if ((checked && !isEnabled) || (!checked && isEnabled)) {
        // Click the button to switch between modes
        btn.click();
      }
    }, 50);
  });
}
```

The handler will get called with these arguments:
```
isEnabled - Is Dark Mode enabled (true) or disabled (false)
config:
  enableDarkMode - Enable DarkReader
  injectDarkModeStyle - Inject darkmode.css
  removeDarkModeStyle - Remove service's darkmode.css
  disableDarkMode - Disable DarkReader
  isDarkModeStyleInjected - Function that returns true if darkmode.css is injected into the page
```

Ferdi won't activate DarkReader or inject darkmode.css if the recipe has a custom handler, but `config.injectDarkModeStyle()` or `config.enableDarkMode()` can be used inside the custom handler to still do this.

This is the first Ferdi-specific API change for recipes, thus we will also need to create our own recipe docs. For this, I will copy Franz's recipe docs (https://github.com/meetfranz/plugins/tree/master/docs) into our recipe repository and add this new function to the docs.


### How Has This Been Tested?
This has been tested with the code snipped found above but still needs more testing

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
