### PR TITLE
add option to disable reload after resume

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -255,6 +255,7 @@ export default @observer class EditSettingsForm extends Component {
             <Toggle field={form.$('autoLaunchOnStart')} />
             <Toggle field={form.$('runInBackground')} />
             <Toggle field={form.$('enableSystemTray')} />
+            <Toggle field={form.$('reloadAfterResume')} />
             {isTrayEnabled && <Toggle field={form.$('startMinimized')} />}
             {process.platform === 'win32' && (
               <Toggle field={form.$('minimizeToSystemTray')} />

--- a/src/config.js
+++ b/src/config.js
@@ -76,6 +76,7 @@ export const iconSizeBias = 20;
 export const DEFAULT_APP_SETTINGS = {
   autoLaunchInBackground: false,
   runInBackground: true,
+  reloadAfterResume: true,
   enableSystemTray: true,
   startMinimized: false,
   minimizeToSystemTray: false,

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -547,7 +547,6 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           hibernationEnabled={this.props.stores.settings.app.hibernate}
           isDarkmodeEnabled={this.props.stores.settings.app.darkMode}
           isTrayEnabled={this.props.stores.settings.app.enableSystemTray}
-          isReloadAfterResumeEnabled={this.props.stores.settings.app.isReloadAfterResumeEnabled}
           isAdaptableDarkModeEnabled={this.props.stores.settings.app.adaptableDarkMode}
           openProcessManager={() => this.openProcessManager()}
         />

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -48,6 +48,10 @@ const messages = defineMessages({
     id: 'settings.app.form.enableSystemTray',
     defaultMessage: '!!!Always show Ferdi in system tray',
   },
+  reloadAfterResume: {
+    id: 'settings.app.form.reloadAfterResume',
+    defaultMessage: '!!!Reload Ferdi after system resume',
+  },
   minimizeToSystemTray: {
     id: 'settings.app.form.minimizeToSystemTray',
     defaultMessage: '!!!Minimize Ferdi to system tray',
@@ -195,6 +199,7 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
       data: {
         runInBackground: settingsData.runInBackground,
         enableSystemTray: settingsData.enableSystemTray,
+        reloadAfterResume: settingsData.reloadAfterResume,
         startMinimized: settingsData.startMinimized,
         minimizeToSystemTray: settingsData.minimizeToSystemTray,
         privateNotifications: settingsData.privateNotifications,
@@ -316,6 +321,11 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           label: intl.formatMessage(messages.enableSystemTray),
           value: settings.all.app.enableSystemTray,
           default: DEFAULT_APP_SETTINGS.enableSystemTray,
+        },
+        reloadAfterResume: {
+          label: intl.formatMessage(messages.reloadAfterResume),
+          value: settings.all.app.reloadAfterResume,
+          default: DEFAULT_APP_SETTINGS.reloadAfterResume,
         },
         minimizeToSystemTray: {
           label: intl.formatMessage(messages.minimizeToSystemTray),
@@ -537,6 +547,7 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           hibernationEnabled={this.props.stores.settings.app.hibernate}
           isDarkmodeEnabled={this.props.stores.settings.app.darkMode}
           isTrayEnabled={this.props.stores.settings.app.enableSystemTray}
+          isReloadAfterResumeEnabled={this.props.stores.settings.app.isReloadAfterResumeEnabled}
           isAdaptableDarkModeEnabled={this.props.stores.settings.app.adaptableDarkMode}
           openProcessManager={() => this.openProcessManager()}
         />

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -4227,393 +4227,406 @@
         }
       },
       {
-        "defaultMessage": "!!!Minimize Ferdi to system tray",
+        "defaultMessage": "!!!Reload Ferdi after system resume",
         "end": {
           "column": 3,
           "line": 54
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.minimizeToSystemTray",
+        "id": "settings.app.form.reloadAfterResume",
         "start": {
-          "column": 24,
+          "column": 21,
           "line": 51
         }
       },
       {
-        "defaultMessage": "!!!Don't show message content in notifications",
+        "defaultMessage": "!!!Minimize Ferdi to system tray",
         "end": {
           "column": 3,
           "line": 58
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.privateNotifications",
+        "id": "settings.app.form.minimizeToSystemTray",
         "start": {
           "column": 24,
           "line": 55
         }
       },
       {
-        "defaultMessage": "!!!Navigation bar behaviour",
+        "defaultMessage": "!!!Don't show message content in notifications",
         "end": {
           "column": 3,
           "line": 62
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.privateNotifications",
+        "start": {
+          "column": 24,
+          "line": 59
+        }
+      },
+      {
+        "defaultMessage": "!!!Navigation bar behaviour",
+        "end": {
+          "column": 3,
+          "line": 66
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.navigationBarBehaviour",
         "start": {
           "column": 26,
-          "line": 59
+          "line": 63
         }
       },
       {
         "defaultMessage": "!!!Send telemetry data",
         "end": {
           "column": 3,
-          "line": 66
+          "line": 70
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.sentry",
         "start": {
           "column": 10,
-          "line": 63
+          "line": 67
         }
       },
       {
         "defaultMessage": "!!!Enable service hibernation",
         "end": {
           "column": 3,
-          "line": 70
+          "line": 74
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.hibernate",
         "start": {
           "column": 13,
-          "line": 67
+          "line": 71
         }
       },
       {
         "defaultMessage": "!!!Hibernation strategy",
         "end": {
           "column": 3,
-          "line": 74
+          "line": 78
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.hibernationStrategy",
         "start": {
           "column": 23,
-          "line": 71
+          "line": 75
         }
       },
       {
         "defaultMessage": "!!!Server",
         "end": {
           "column": 3,
-          "line": 78
+          "line": 82
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.server",
         "start": {
           "column": 10,
-          "line": 75
+          "line": 79
         }
       },
       {
         "defaultMessage": "!!!Todo Server",
         "end": {
           "column": 3,
-          "line": 82
-        },
-        "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.todoServer",
-        "start": {
-          "column": 14,
-          "line": 79
-        }
-      },
-      {
-        "defaultMessage": "!!!Enable Password Lock",
-        "end": {
-          "column": 3,
           "line": 86
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.enableLock",
+        "id": "settings.app.form.todoServer",
         "start": {
           "column": 14,
           "line": 83
         }
       },
       {
-        "defaultMessage": "!!!Password",
+        "defaultMessage": "!!!Enable Password Lock",
         "end": {
           "column": 3,
           "line": 90
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.enableLock",
+        "start": {
+          "column": 14,
+          "line": 87
+        }
+      },
+      {
+        "defaultMessage": "!!!Password",
+        "end": {
+          "column": 3,
+          "line": 94
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.lockPassword",
         "start": {
           "column": 16,
-          "line": 87
+          "line": 91
         }
       },
       {
         "defaultMessage": "!!!Allow using Touch ID to unlock",
         "end": {
           "column": 3,
-          "line": 94
+          "line": 98
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.useTouchIdToUnlock",
         "start": {
           "column": 22,
-          "line": 91
+          "line": 95
         }
       },
       {
         "defaultMessage": "!!!Lock after inactivity",
         "end": {
           "column": 3,
-          "line": 98
+          "line": 102
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.inactivityLock",
         "start": {
           "column": 18,
-          "line": 95
+          "line": 99
         }
       },
       {
         "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
         "end": {
           "column": 3,
-          "line": 102
+          "line": 106
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDEnabled",
         "start": {
           "column": 23,
-          "line": 99
+          "line": 103
         }
       },
       {
         "defaultMessage": "!!!From",
         "end": {
           "column": 3,
-          "line": 106
+          "line": 110
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDStart",
         "start": {
           "column": 21,
-          "line": 103
+          "line": 107
         }
       },
       {
         "defaultMessage": "!!!To",
         "end": {
           "column": 3,
-          "line": 110
+          "line": 114
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDEnd",
         "start": {
           "column": 19,
-          "line": 107
+          "line": 111
         }
       },
       {
         "defaultMessage": "!!!Language",
         "end": {
           "column": 3,
-          "line": 114
-        },
-        "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.language",
-        "start": {
-          "column": 12,
-          "line": 111
-        }
-      },
-      {
-        "defaultMessage": "!!!Dark Mode",
-        "end": {
-          "column": 3,
           "line": 118
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.darkMode",
+        "id": "settings.app.form.language",
         "start": {
           "column": 12,
           "line": 115
         }
       },
       {
-        "defaultMessage": "!!!Synchronize dark mode with my Mac's dark mode setting",
+        "defaultMessage": "!!!Dark Mode",
         "end": {
           "column": 3,
           "line": 122
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.adaptableDarkMode",
+        "id": "settings.app.form.darkMode",
         "start": {
-          "column": 21,
+          "column": 12,
           "line": 119
         }
       },
       {
-        "defaultMessage": "!!!Enable universal Dark Mode",
+        "defaultMessage": "!!!Synchronize dark mode with my Mac's dark mode setting",
         "end": {
           "column": 3,
           "line": 126
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.universalDarkMode",
+        "id": "settings.app.form.adaptableDarkMode",
         "start": {
           "column": 21,
           "line": 123
         }
       },
       {
-        "defaultMessage": "!!!Sidebar width",
+        "defaultMessage": "!!!Enable universal Dark Mode",
         "end": {
           "column": 3,
           "line": 130
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.universalDarkMode",
+        "start": {
+          "column": 21,
+          "line": 127
+        }
+      },
+      {
+        "defaultMessage": "!!!Sidebar width",
+        "end": {
+          "column": 3,
+          "line": 134
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.serviceRibbonWidth",
         "start": {
           "column": 22,
-          "line": 127
+          "line": 131
         }
       },
       {
         "defaultMessage": "!!!Service icon size",
         "end": {
           "column": 3,
-          "line": 134
+          "line": 138
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.iconSize",
         "start": {
           "column": 12,
-          "line": 131
+          "line": 135
         }
       },
       {
         "defaultMessage": "!!!Accent color",
         "end": {
           "column": 3,
-          "line": 138
+          "line": 142
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.accentColor",
         "start": {
           "column": 15,
-          "line": 135
+          "line": 139
         }
       },
       {
         "defaultMessage": "!!!Display disabled services tabs",
         "end": {
           "column": 3,
-          "line": 142
+          "line": 146
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showDisabledServices",
         "start": {
           "column": 24,
-          "line": 139
+          "line": 143
         }
       },
       {
         "defaultMessage": "!!!Show unread message badge when notifications are disabled",
         "end": {
           "column": 3,
-          "line": 146
+          "line": 150
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showMessagesBadgesWhenMuted",
         "start": {
           "column": 29,
-          "line": 143
+          "line": 147
         }
       },
       {
         "defaultMessage": "!!!Enable spell checking",
         "end": {
           "column": 3,
-          "line": 150
+          "line": 154
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableSpellchecking",
         "start": {
           "column": 23,
-          "line": 147
+          "line": 151
         }
       },
       {
         "defaultMessage": "!!!Enable GPU Acceleration",
         "end": {
           "column": 3,
-          "line": 154
+          "line": 158
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableGPUAcceleration",
         "start": {
           "column": 25,
-          "line": 151
+          "line": 155
         }
       },
       {
         "defaultMessage": "!!!Include beta versions",
         "end": {
           "column": 3,
-          "line": 158
+          "line": 162
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.beta",
         "start": {
           "column": 8,
-          "line": 155
+          "line": 159
         }
       },
       {
         "defaultMessage": "!!!Disable updates",
         "end": {
           "column": 3,
-          "line": 162
+          "line": 166
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.noUpdates",
         "start": {
           "column": 13,
-          "line": 159
+          "line": 163
         }
       },
       {
         "defaultMessage": "!!!Enable Franz Todos",
         "end": {
           "column": 3,
-          "line": 166
+          "line": 170
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableTodos",
         "start": {
           "column": 15,
-          "line": 163
+          "line": 167
         }
       },
       {
         "defaultMessage": "!!!Keep all workspaces loaded",
         "end": {
           "column": 3,
-          "line": 170
+          "line": 174
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.keepAllWorkspacesLoaded",
         "start": {
           "column": 27,
-          "line": 167
+          "line": 171
         }
       }
     ],

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -290,6 +290,7 @@
   "settings.app.form.navigationBarBehaviour": "Navigation bar behaviour",
   "settings.app.form.noUpdates": "Disable updates",
   "settings.app.form.privateNotifications": "Don't show message content in notifications",
+  "settings.app.form.reloadAfterResume": "Reload Ferdi after system resume",
   "settings.app.form.runInBackground": "Keep Ferdi in background when closing the window",
   "settings.app.form.scheduledDNDEnabled": "Enable scheduled Do-not-Disturb",
   "settings.app.form.scheduledDNDEnd": "To",

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -65,12 +65,12 @@
     }
   },
   {
-    "id": "settings.app.form.minimizeToSystemTray",
-    "defaultMessage": "!!!Minimize Ferdi to system tray",
+    "id": "settings.app.form.reloadAfterResume",
+    "defaultMessage": "!!!Reload Ferdi after system resume",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 51,
-      "column": 24
+      "column": 21
     },
     "end": {
       "line": 54,
@@ -78,8 +78,8 @@
     }
   },
   {
-    "id": "settings.app.form.privateNotifications",
-    "defaultMessage": "!!!Don't show message content in notifications",
+    "id": "settings.app.form.minimizeToSystemTray",
+    "defaultMessage": "!!!Minimize Ferdi to system tray",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 55,
@@ -91,15 +91,28 @@
     }
   },
   {
+    "id": "settings.app.form.privateNotifications",
+    "defaultMessage": "!!!Don't show message content in notifications",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 59,
+      "column": 24
+    },
+    "end": {
+      "line": 62,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.navigationBarBehaviour",
     "defaultMessage": "!!!Navigation bar behaviour",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 59,
+      "line": 63,
       "column": 26
     },
     "end": {
-      "line": 62,
+      "line": 66,
       "column": 3
     }
   },
@@ -108,11 +121,11 @@
     "defaultMessage": "!!!Send telemetry data",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 63,
+      "line": 67,
       "column": 10
     },
     "end": {
-      "line": 66,
+      "line": 70,
       "column": 3
     }
   },
@@ -121,11 +134,11 @@
     "defaultMessage": "!!!Enable service hibernation",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 67,
+      "line": 71,
       "column": 13
     },
     "end": {
-      "line": 70,
+      "line": 74,
       "column": 3
     }
   },
@@ -134,11 +147,11 @@
     "defaultMessage": "!!!Hibernation strategy",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 71,
+      "line": 75,
       "column": 23
     },
     "end": {
-      "line": 74,
+      "line": 78,
       "column": 3
     }
   },
@@ -147,21 +160,8 @@
     "defaultMessage": "!!!Server",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 75,
-      "column": 10
-    },
-    "end": {
-      "line": 78,
-      "column": 3
-    }
-  },
-  {
-    "id": "settings.app.form.todoServer",
-    "defaultMessage": "!!!Todo Server",
-    "file": "src/containers/settings/EditSettingsScreen.js",
-    "start": {
       "line": 79,
-      "column": 14
+      "column": 10
     },
     "end": {
       "line": 82,
@@ -169,8 +169,8 @@
     }
   },
   {
-    "id": "settings.app.form.enableLock",
-    "defaultMessage": "!!!Enable Password Lock",
+    "id": "settings.app.form.todoServer",
+    "defaultMessage": "!!!Todo Server",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 83,
@@ -182,15 +182,28 @@
     }
   },
   {
+    "id": "settings.app.form.enableLock",
+    "defaultMessage": "!!!Enable Password Lock",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 87,
+      "column": 14
+    },
+    "end": {
+      "line": 90,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.lockPassword",
     "defaultMessage": "!!!Password",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 87,
+      "line": 91,
       "column": 16
     },
     "end": {
-      "line": 90,
+      "line": 94,
       "column": 3
     }
   },
@@ -199,11 +212,11 @@
     "defaultMessage": "!!!Allow using Touch ID to unlock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 91,
+      "line": 95,
       "column": 22
     },
     "end": {
-      "line": 94,
+      "line": 98,
       "column": 3
     }
   },
@@ -212,11 +225,11 @@
     "defaultMessage": "!!!Lock after inactivity",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 95,
+      "line": 99,
       "column": 18
     },
     "end": {
-      "line": 98,
+      "line": 102,
       "column": 3
     }
   },
@@ -225,11 +238,11 @@
     "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 99,
+      "line": 103,
       "column": 23
     },
     "end": {
-      "line": 102,
+      "line": 106,
       "column": 3
     }
   },
@@ -238,11 +251,11 @@
     "defaultMessage": "!!!From",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 103,
+      "line": 107,
       "column": 21
     },
     "end": {
-      "line": 106,
+      "line": 110,
       "column": 3
     }
   },
@@ -251,21 +264,8 @@
     "defaultMessage": "!!!To",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 107,
-      "column": 19
-    },
-    "end": {
-      "line": 110,
-      "column": 3
-    }
-  },
-  {
-    "id": "settings.app.form.language",
-    "defaultMessage": "!!!Language",
-    "file": "src/containers/settings/EditSettingsScreen.js",
-    "start": {
       "line": 111,
-      "column": 12
+      "column": 19
     },
     "end": {
       "line": 114,
@@ -273,8 +273,8 @@
     }
   },
   {
-    "id": "settings.app.form.darkMode",
-    "defaultMessage": "!!!Dark Mode",
+    "id": "settings.app.form.language",
+    "defaultMessage": "!!!Language",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 115,
@@ -286,12 +286,12 @@
     }
   },
   {
-    "id": "settings.app.form.adaptableDarkMode",
-    "defaultMessage": "!!!Synchronize dark mode with my Mac's dark mode setting",
+    "id": "settings.app.form.darkMode",
+    "defaultMessage": "!!!Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 119,
-      "column": 21
+      "column": 12
     },
     "end": {
       "line": 122,
@@ -299,8 +299,8 @@
     }
   },
   {
-    "id": "settings.app.form.universalDarkMode",
-    "defaultMessage": "!!!Enable universal Dark Mode",
+    "id": "settings.app.form.adaptableDarkMode",
+    "defaultMessage": "!!!Synchronize dark mode with my Mac's dark mode setting",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 123,
@@ -312,15 +312,28 @@
     }
   },
   {
+    "id": "settings.app.form.universalDarkMode",
+    "defaultMessage": "!!!Enable universal Dark Mode",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 127,
+      "column": 21
+    },
+    "end": {
+      "line": 130,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.serviceRibbonWidth",
     "defaultMessage": "!!!Sidebar width",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 127,
+      "line": 131,
       "column": 22
     },
     "end": {
-      "line": 130,
+      "line": 134,
       "column": 3
     }
   },
@@ -329,11 +342,11 @@
     "defaultMessage": "!!!Service icon size",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 131,
+      "line": 135,
       "column": 12
     },
     "end": {
-      "line": 134,
+      "line": 138,
       "column": 3
     }
   },
@@ -342,11 +355,11 @@
     "defaultMessage": "!!!Accent color",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 135,
+      "line": 139,
       "column": 15
     },
     "end": {
-      "line": 138,
+      "line": 142,
       "column": 3
     }
   },
@@ -355,11 +368,11 @@
     "defaultMessage": "!!!Display disabled services tabs",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 139,
+      "line": 143,
       "column": 24
     },
     "end": {
-      "line": 142,
+      "line": 146,
       "column": 3
     }
   },
@@ -368,11 +381,11 @@
     "defaultMessage": "!!!Show unread message badge when notifications are disabled",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 143,
+      "line": 147,
       "column": 29
     },
     "end": {
-      "line": 146,
+      "line": 150,
       "column": 3
     }
   },
@@ -381,11 +394,11 @@
     "defaultMessage": "!!!Enable spell checking",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 147,
+      "line": 151,
       "column": 23
     },
     "end": {
-      "line": 150,
+      "line": 154,
       "column": 3
     }
   },
@@ -394,11 +407,11 @@
     "defaultMessage": "!!!Enable GPU Acceleration",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 151,
+      "line": 155,
       "column": 25
     },
     "end": {
-      "line": 154,
+      "line": 158,
       "column": 3
     }
   },
@@ -407,11 +420,11 @@
     "defaultMessage": "!!!Include beta versions",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 155,
+      "line": 159,
       "column": 8
     },
     "end": {
-      "line": 158,
+      "line": 162,
       "column": 3
     }
   },
@@ -420,11 +433,11 @@
     "defaultMessage": "!!!Disable updates",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 159,
+      "line": 163,
       "column": 13
     },
     "end": {
-      "line": 162,
+      "line": 166,
       "column": 3
     }
   },
@@ -433,11 +446,11 @@
     "defaultMessage": "!!!Enable Franz Todos",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 163,
+      "line": 167,
       "column": 15
     },
     "end": {
-      "line": 166,
+      "line": 170,
       "column": 3
     }
   },
@@ -446,11 +459,11 @@
     "defaultMessage": "!!!Keep all workspaces loaded",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 167,
+      "line": 171,
       "column": 27
     },
     "end": {
-      "line": 170,
+      "line": 174,
       "column": 3
     }
   }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -202,7 +202,7 @@ export default class AppStore extends Store {
     powerMonitor.on('resume', () => {
       debug('System resumed, last suspended on', this.timeSuspensionStart.toString());
 
-      if (this.timeSuspensionStart.add(10, 'm').isBefore(moment())) {
+      if (this.timeSuspensionStart.add(10, 'm').isBefore(moment()) && this.stores.settings.app.get('reloadAfterResume')) {
         debug('Reloading services, user info and features');
 
         setTimeout(() => {


### PR DESCRIPTION
closes #442

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
I found it annoying, that all my services would reload, after resuming my system from hibernation. Therefor I added a option in the settings to thisable this behaviour.

### Screenshots:
![Screenshot from 2020-03-09 01-12-33](https://user-images.githubusercontent.com/22817873/76173821-1221f400-61a3-11ea-82de-61f1537cec5b.png)


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
