### PR TITLE
Reflect service name in application title

### DIFF
--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -154,6 +154,10 @@ class TabItem extends Component {
       );
     }
 
+    if (service.isActive) {
+      document.title = "Ferdi - " + service.name;
+    }
+
     return (
       <li
         className={classnames({


### PR DESCRIPTION
Reflect active service in title

### Description
For example if you have 3 services Whatsapp, Slack, Linkedin, if Linkedin is active title will be "Ferdi - Linkedin" instead "Ferdi".

### Motivation and Context
Useful for password manager like KeepassXC, Keeweb, ... who can rely user/pass based on title
fix : https://github.com/getferdi/ferdi/issues/213

### How Has This Been Tested?
Tested on mac OS Catalina with Ferdi (develop) and Keeweb 1.12.3

### Screenshots (if appropriate):

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
