### PR TITLE
Reflect service name in application title

### DIFF
--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -699,6 +699,7 @@ export default class ServicesStore extends Store {
     const service = this.active;
     if (service) {
       this.actions.service.focusService({ serviceId: service.id });
+      document.title = `Ferdi - ${service.name}`;
     }
   }
 


### PR DESCRIPTION
Reflect active service in title

### Description
For example if you have 3 services Whatsapp, Slack, Linkedin, if Linkedin is active title will be "Ferdi - Linkedin" instead "Ferdi".

### Motivation and Context
Useful for password manager like KeepassXC, Keeweb, ... who can rely user/pass based on title
fix : https://github.com/getferdi/ferdi/issues/213
Move code to ServiceStore

### How Has This Been Tested?
Tested on mac OS Catalina with Ferdi (develop) and Keeweb 1.12.3

### Screenshots (if appropriate):

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
