### PR TITLE
Develop service link

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -16,6 +16,9 @@ export default {
   openExternalUrl: {
     url: PropTypes.string.isRequired,
   },
+  openServiceUrl: {
+    event: PropTypes.object.isRequired,
+  },
   checkForUpdates: {},
   resetUpdateStatus: {},
   installUpdate: {},

--- a/src/actions/service.js
+++ b/src/actions/service.js
@@ -70,6 +70,10 @@ export default {
   openWindow: {
     event: PropTypes.object.isRequired,
   },
+  openServiceWindow: {
+    event: PropTypes.object.isRequired,
+    serviceId: PropTypes.string.isRequired,
+  },
   reload: {
     serviceId: PropTypes.string.isRequired,
   },

--- a/src/features/todos/components/TodosWebview.js
+++ b/src/features/todos/components/TodosWebview.js
@@ -176,7 +176,7 @@ class TodosWebview extends Component {
     const { handleClientMessage } = this.props;
     if (!this.webview) return;
     this.webview.addEventListener('ipc-message', e => handleClientMessage(e.args[0]));
-    this.webview.addEventListener('new-window', e => {
+    this.webview.addEventListener('new-window', (e) => {
       if (e.frameName && e.frameName.includes('Ferdi:')) {
         const message = {};
         message.action = 'todos:goToService';

--- a/src/features/todos/components/TodosWebview.js
+++ b/src/features/todos/components/TodosWebview.js
@@ -176,6 +176,16 @@ class TodosWebview extends Component {
     const { handleClientMessage } = this.props;
     if (!this.webview) return;
     this.webview.addEventListener('ipc-message', e => handleClientMessage(e.args[0]));
+    this.webview.addEventListener('new-window', e => {
+      if (e.frameName && e.frameName.includes('Ferdi:')) {
+        const message = {};
+        message.action = 'todos:goToService';
+        message.data = {};
+        message.data.url = e.url;
+        message.data.serviceName = e.frameName.split('Ferdi: ')[1];
+        handleClientMessage(message);
+      }
+    });
   }
 
   render() {

--- a/src/features/todos/store.js
+++ b/src/features/todos/store.js
@@ -166,17 +166,28 @@ export default class TodoStore extends FeatureStore {
     this.webview.addEventListener('new-window', ({ url }) => {
       this.actions.app.openExternalUrl({ url });
     });
-    this.webview.addEventListener('service-window', ({ event, serviceId }) => {
-      event.serviceId = serviceId;
-      this.actions.app.openServiceUrl({ event });
-    });
   };
 
-  _goToService = ({ url, serviceId }) => {
-    if (url) {
-      this.stores.services.one(serviceId).webview.loadURL(url);
+  _goToService = ({ url, serviceId, serviceName }) => {
+    if (serviceId) {
+      if (url) {
+        this.stores.services.one(serviceId).webview.loadURL(url);
+      }
+      this.actions.service.setActive({ serviceId });
+    } else if (serviceName) {
+      let searchServiceId = 'not-found';
+      this.stores.services.allDisplayed.forEach((s) => {
+        if (s.name === serviceName) {
+          searchServiceId = s.id;
+        }
+      });
+      if (searchServiceId !== 'not-found') {
+        if (url) {
+          this.stores.services.one(searchServiceId).webview.loadURL(url);
+        }
+        this.actions.service.setActive({ searchServiceId });
+      }
     }
-    this.actions.service.setActive({ serviceId });
   };
 
   // Reactions

--- a/src/features/todos/store.js
+++ b/src/features/todos/store.js
@@ -166,6 +166,10 @@ export default class TodoStore extends FeatureStore {
     this.webview.addEventListener('new-window', ({ url }) => {
       this.actions.app.openExternalUrl({ url });
     });
+    this.webview.addEventListener('service-window', ({ event, serviceId }) => {
+      event.serviceId = serviceId;
+      this.actions.app.openServiceUrl({ event });
+    });
   };
 
   _goToService = ({ url, serviceId }) => {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -24,6 +24,8 @@ import { getServiceIdsFromPartitions, removeServicePartitionDirectory } from '..
 import { isValidExternalURL } from '../helpers/url-helpers';
 import { sleep } from '../helpers/async-helpers';
 
+const uuid = require('uuid/v4');
+
 const debug = require('debug')('Ferdi:AppStore');
 
 const {
@@ -92,6 +94,7 @@ export default class AppStore extends Store {
     this.actions.app.setBadge.listen(this._setBadge.bind(this));
     this.actions.app.launchOnStartup.listen(this._launchOnStartup.bind(this));
     this.actions.app.openExternalUrl.listen(this._openExternalUrl.bind(this));
+    this.actions.app.openServiceUrl.listen(this._openServiceUrl.bind(this));
     this.actions.app.checkForUpdates.listen(this._checkForUpdates.bind(this));
     this.actions.app.installUpdate.listen(this._installUpdate.bind(this));
     this.actions.app.resetUpdateStatus.listen(this._resetUpdateStatus.bind(this));
@@ -333,6 +336,18 @@ export default class AppStore extends Store {
     if (isValidExternalURL(url)) {
       shell.openExternal(url);
     }
+  }
+
+  @action _openServiceUrl({ event }) {
+    const serviceId = event.serviceId;
+    const parsedUrl = new URL(event.url);
+    const notificationId = uuid();
+    this.actions.service.sendIPCMessage({
+      channel: `notification-onclick:${notificationId}`,
+      args: event,
+      serviceId,
+    });
+    this.actions.service.setActive({ serviceId });
   }
 
   @action _checkForUpdates() {

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -340,7 +340,6 @@ export default class AppStore extends Store {
 
   @action _openServiceUrl({ event }) {
     const serviceId = event.serviceId;
-    const parsedUrl = new URL(event.url);
     const notificationId = uuid();
     this.actions.service.sendIPCMessage({
       channel: `notification-onclick:${notificationId}`,

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -519,17 +519,16 @@ export default class ServicesStore extends Store {
     } else if (channel === 'service-window') {
       const event = args[0];
       const url = args[0].url;
-      let serviceId = 'not-found';
+      let searchServiceId = 'not-found';
       this.allDisplayed.forEach((s) => {
         if (s.name === event.serviceName) {
-          serviceId = s.id;
+          searchServiceId = s.id;
         }
       });
-      if (serviceId === 'not-found') {
+      if (searchServiceId === 'not-found') {
         this.actions.app.openExternalUrl({ url });
       } else {
-        event.serviceId = serviceId;
-        console.log(serviceId);
+        event.serviceId = searchServiceId;
         this.actions.app.openServiceUrl({ event });
       }
     } else if (channel === 'avatar') {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -518,7 +518,20 @@ export default class ServicesStore extends Store {
       }
     } else if (channel === 'service-window') {
       const event = args[0];
-      this.actions.app.openServiceUrl({ event });
+      const url = args[0].url;
+      let serviceId = 'not-found';
+      this.allDisplayed.forEach((s) => {
+        if (s.name === event.serviceName) {
+          serviceId = s.id;
+        }
+      });
+      if (serviceId === 'not-found') {
+        this.actions.app.openExternalUrl({ url });
+      } else {
+        event.serviceId = serviceId;
+        console.log(serviceId);
+        this.actions.app.openServiceUrl({ event });
+      }
     } else if (channel === 'avatar') {
       const url = args[0];
       if (service.iconUrl !== url && !service.hasCustomUploadedIcon) {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -517,10 +517,8 @@ export default class ServicesStore extends Store {
         });
       }
     } else if (channel === 'service-window') {
-      
       const event = args[0];
       this.actions.app.openServiceUrl({ event });
-
     } else if (channel === 'avatar') {
       const url = args[0];
       if (service.iconUrl !== url && !service.hasCustomUploadedIcon) {
@@ -561,7 +559,7 @@ export default class ServicesStore extends Store {
     const currentURL = service.webview.getURL();
     if (args && args.url && service.webview && args.url !== currentURL) {
       service.webview.loadURL(args.url);
-    } 
+    }
     if (service.webview) {
       service.webview.send(channel, args);
     }

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -516,6 +516,11 @@ export default class ServicesStore extends Store {
           serviceId,
         });
       }
+    } else if (channel === 'service-window') {
+      
+      const event = args[0];
+      this.actions.app.openServiceUrl({ event });
+
     } else if (channel === 'avatar') {
       const url = args[0];
       if (service.iconUrl !== url && !service.hasCustomUploadedIcon) {
@@ -553,7 +558,10 @@ export default class ServicesStore extends Store {
 
   @action _sendIPCMessage({ serviceId, channel, args }) {
     const service = this.one(serviceId);
-
+    const currentURL = service.webview.getURL();
+    if (args && args.url && service.webview && args.url !== currentURL) {
+      service.webview.loadURL(args.url);
+    } 
     if (service.webview) {
       service.webview.send(channel, args);
     }

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -355,6 +355,14 @@ window.open = (url, frameName, features) => {
     return ipcRenderer.sendToHost('new-window', url);
   }
 
+  if (frameName && frameName.includes('Ferdi:')) {
+    const event = {};
+    event.url = url;
+    event.frameName = frameName;
+    event.serviceId = features;
+    return ipcRenderer.sendToHost('service-window', event);
+  }
+
   if (url) {
     return originalWindowOpen(url, frameName, features);
   }

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -359,7 +359,7 @@ window.open = (url, frameName, features) => {
     const event = {};
     event.url = url;
     event.frameName = frameName;
-    event.serviceId = features;
+    event.serviceName = features;
     return ipcRenderer.sendToHost('service-window', event);
   }
 


### PR DESCRIPTION
Be able to open an url from a service into another service
Be able to open an url from Todo into another service

### Description
Add a service-window listener

### Motivation and Context
This prevent if correctly configured to go out of Ferdi
https://github.com/getferdi/ferdi/issues/451

### How Has This Been Tested?
Tested on mac OS X with some custom websites.
Need to use user.js to tranform all target _blank link for a specific service to another.

### Example : 
You have a Trello Service named : "Trello" and a Slack service named : "Slack" and you want to go into Trello tab when a Slack message contains a Trello link.

You need to transform via user.js all : 
<a href="https://www.trello.com/blah" target="_blank">Blah</a>

BY
<a href="javascript:window.open('https://www.trello.com/blah', 'Ferdi: Trello', 'Trello');"

OR
<a href="javascript:window.open('https://www.trello.com/blah', 'Ferdi: ServiceName', 'ServiceName');"
WHERE
ServiceName is the name of your Service.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x ] My code follows the code style of this project (run `$ yarn lint`).
- [ ] I have updated the documentation accordingly. 
