### PR TITLE
Support new recipe repository hierarchy

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -41,7 +41,7 @@ const paths = {
   tmp: '.tmp',
   package: `out/${config.version}`,
   recipes: {
-    src: 'recipes/*.tar.gz',
+    src: 'recipes/archives/*.tar.gz',
     dest: 'build/recipes/',
   },
   recipeInfo: {


### PR DESCRIPTION
In an effort to make the recipe repository more accessible, the archives were moved into a separate `archives/` subfolder.

This PR will configure the gulpfile to support this change.