### PR TITLE
Add retry commands to flaky build steps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ before_install:
 install:
   - echo do nothing
 before_script:
-  - npx lerna bootstrap
-  - npm install node-sass -g
+  - travis_retry npx lerna bootstrap
+  - travis_retry npm install node-sass -g
 script:
-  - travis_wait 100 npm run build
+  - travis_retry travis_wait 100 npm run build
 cache: npm
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ before_build:
   - cmd: set NODE_ENV=production
 
 build_script:
-  - npm run build
+  - appveyor-retry npm run build
 
 branches:
   except:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Use retry commands for [Travis](https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies) and [AppVeyor](https://github.com/appveyor/ci/issues/418) on unreliable build steps.
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We often see failing builds that would pass if manually retried. This should help not having to intervene manually to retry builds failing due to flaky build steps.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Not tested at the time of writing, hopefully all the checks will be green in this pull request and in the future (or at least failing for legitimate issues).


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
