### PR TITLE
Remove server setting from settings screen

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -18,15 +18,6 @@ const {
   systemPreferences,
 } = remote;
 
-function escapeHtml(unsafe) {
-  return unsafe
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
 const messages = defineMessages({
   headline: {
     id: 'settings.app.headline',
@@ -47,14 +38,6 @@ const messages = defineMessages({
   inactivityLockInfo: {
     id: 'settings.app.inactivityLockInfo',
     defaultMessage: '!!!Minutes of inactivity, after which Ferdi should automatically lock. Use 0 to disable',
-  },
-  serverInfo: {
-    id: 'settings.app.serverInfo',
-    defaultMessage: '!!!We advice you to logout after changing your server as your settings might not be saved otherwise.',
-  },
-  serverMoneyInfo: {
-    id: 'settings.app.serverMoneyInfo',
-    defaultMessage: '!!!You are using the official Franz Server for Ferdi.\nWe know that Ferdi allows you to use all its features for free but you are still using Franz\'s server resources - which Franz\'s creator has to pay for.\nPlease still consider [Link 1]paying for a Franz account[/Link] or [Link 2]using a self-hosted ferdi-server[/Link] (if you have the knowledge and resources to do so). \nBy using Ferdi, you still profit greatly from Franz\'s recipe store, server resources and its development.',
   },
   todoServerInfo: {
     id: 'settings.app.todoServerInfo',
@@ -174,7 +157,6 @@ export default @observer class EditSettingsForm extends Component {
     isSpellcheckerIncludedInCurrentPlan: PropTypes.bool.isRequired,
     isTodosEnabled: PropTypes.bool.isRequired,
     isWorkspaceEnabled: PropTypes.bool.isRequired,
-    server: PropTypes.string.isRequired,
     noUpdates: PropTypes.bool.isRequired,
     hibernationEnabled: PropTypes.bool.isRequired,
     isDarkmodeEnabled: PropTypes.bool.isRequired,
@@ -214,7 +196,6 @@ export default @observer class EditSettingsForm extends Component {
       isSpellcheckerIncludedInCurrentPlan,
       isTodosEnabled,
       isWorkspaceEnabled,
-      server,
       noUpdates,
       hibernationEnabled,
       isDarkmodeEnabled,
@@ -231,8 +212,6 @@ export default @observer class EditSettingsForm extends Component {
     } else {
       updateButtonLabelMessage = messages.buttonSearchForUpdate;
     }
-
-    const isLoggedIn = Boolean(localStorage.getItem('authToken'));
 
     const {
       lockingFeatureEnabled,
@@ -287,52 +266,9 @@ export default @observer class EditSettingsForm extends Component {
 
             <Hr />
 
-            <Input
-              placeholder="Server"
-              onChange={e => this.submit(e)}
-              field={form.$('server')}
-              autoFocus
-            />
-            {isLoggedIn && (
-              <p
-                className="settings__message"
-                style={{
-                  borderTop: 0, marginTop: 0, paddingTop: 0, marginBottom: '2rem',
-                }}
-              >
-                { intl.formatMessage(messages.serverInfo) }
-              </p>
-            )}
-            {server === 'https://api.franzinfra.com' && (
-              <p
-                className="settings__message"
-                style={{
-                  borderTop: 0, marginTop: 0, paddingTop: 0, marginBottom: '2rem',
-                }}
-              >
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html:
-                  // Needed to make links work
-                  escapeHtml(
-                    intl.formatMessage(messages.serverMoneyInfo),
-                  ).replace('[Link 1]', '<a href="https://www.meetfranz.com/pricing" target="_blank">')
-                    .replace('[Link 2]', '<a href="https://github.com/getferdi/server" target="_blank">')
-                    .replace(/\[\/Link]/g, '</a>'),
-                  }}
-                  style={{
-                    whiteSpace: 'pre-wrap',
-                  }}
-                />
-              </p>
-            )}
-
-            <Hr />
-
             {isWorkspaceEnabled && (
               <Toggle field={form.$('keepAllWorkspacesLoaded')} />
             )}
-
 
             <Hr />
 

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -20,7 +20,7 @@ import { getSelectOptions } from '../../helpers/i18n-helpers';
 import EditSettingsForm from '../../components/settings/settings/EditSettingsForm';
 import ErrorBoundary from '../../components/util/ErrorBoundary';
 
-import { API, TODOS_FRONTEND } from '../../environment';
+import { TODOS_FRONTEND } from '../../environment';
 
 import globalMessages from '../../i18n/globalMessages';
 import { DEFAULT_IS_FEATURE_ENABLED_BY_USER } from '../../features/todos';
@@ -75,10 +75,6 @@ const messages = defineMessages({
   hibernationStrategy: {
     id: 'settings.app.form.hibernationStrategy',
     defaultMessage: '!!!Hibernation strategy',
-  },
-  server: {
-    id: 'settings.app.form.server',
-    defaultMessage: '!!!Server',
   },
   todoServer: {
     id: 'settings.app.form.todoServer',
@@ -207,7 +203,6 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
         sentry: settingsData.sentry,
         hibernate: settingsData.hibernate,
         hibernationStrategy: settingsData.hibernationStrategy,
-        server: settingsData.server,
         todoServer: settingsData.todoServer,
         lockingFeatureEnabled: settingsData.lockingFeatureEnabled,
         lockedPassword: settingsData.lockedPassword,
@@ -358,11 +353,6 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           value: settings.all.app.hibernationStrategy,
           options: hibernationStrategies,
           default: DEFAULT_APP_SETTINGS.hibernationStrategy,
-        },
-        server: {
-          label: intl.formatMessage(messages.server),
-          value: settings.all.app.server || API,
-          default: API,
         },
         todoServer: {
           label: intl.formatMessage(messages.todoServer),

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -541,7 +541,6 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           isSpellcheckerIncludedInCurrentPlan={spellcheckerConfig.isIncludedInCurrentPlan}
           isTodosEnabled={todos.isFeatureActive}
           isWorkspaceEnabled={workspaces.isFeatureActive}
-          server={this.props.stores.settings.app.server}
           lockingFeatureEnabled={lockingFeatureEnabled}
           noUpdates={this.props.stores.settings.app.noUpdates}
           hibernationEnabled={this.props.stores.settings.app.hibernate}

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -2756,403 +2756,377 @@
         "defaultMessage": "!!!Settings",
         "end": {
           "column": 3,
-          "line": 34
+          "line": 25
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.headline",
         "start": {
           "column": 12,
-          "line": 31
+          "line": 22
         }
       },
       {
         "defaultMessage": "!!!General",
         "end": {
           "column": 3,
-          "line": 38
+          "line": 29
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.headlineGeneral",
         "start": {
           "column": 19,
-          "line": 35
+          "line": 26
         }
       },
       {
         "defaultMessage": "!!!Sending telemetry data allows us to find errors in Ferdi - we will not send any personal information like your message data! Changing this option requires you to restart Ferdi.",
         "end": {
           "column": 3,
-          "line": 42
+          "line": 33
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.sentryInfo",
         "start": {
           "column": 14,
-          "line": 39
+          "line": 30
         }
       },
       {
         "defaultMessage": "!!!By default, Ferdi will keep all your services open and loaded in the background so they are ready when you want to use them. Service Hibernation will unload your services after a specified amount. This is useful to save RAM or keeping services from slowing down your computer.",
         "end": {
           "column": 3,
-          "line": 46
+          "line": 37
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.hibernateInfo",
         "start": {
           "column": 17,
-          "line": 43
+          "line": 34
         }
       },
       {
         "defaultMessage": "!!!Minutes of inactivity, after which Ferdi should automatically lock. Use 0 to disable",
         "end": {
           "column": 3,
-          "line": 50
+          "line": 41
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.inactivityLockInfo",
         "start": {
           "column": 22,
-          "line": 47
-        }
-      },
-      {
-        "defaultMessage": "!!!We advice you to logout after changing your server as your settings might not be saved otherwise.",
-        "end": {
-          "column": 3,
-          "line": 54
-        },
-        "file": "src/components/settings/settings/EditSettingsForm.js",
-        "id": "settings.app.serverInfo",
-        "start": {
-          "column": 14,
-          "line": 51
-        }
-      },
-      {
-        "defaultMessage": "!!!You are using the official Franz Server for Ferdi.\nWe know that Ferdi allows you to use all its features for free but you are still using Franz's server resources - which Franz's creator has to pay for.\nPlease still consider [Link 1]paying for a Franz account[/Link] or [Link 2]using a self-hosted ferdi-server[/Link] (if you have the knowledge and resources to do so). \nBy using Ferdi, you still profit greatly from Franz's recipe store, server resources and its development.",
-        "end": {
-          "column": 3,
-          "line": 58
-        },
-        "file": "src/components/settings/settings/EditSettingsForm.js",
-        "id": "settings.app.serverMoneyInfo",
-        "start": {
-          "column": 19,
-          "line": 55
+          "line": 38
         }
       },
       {
         "defaultMessage": "!!!This server will be used for the \"Franz Todo\" feature. (default: https://app.franztodos.com)",
         "end": {
           "column": 3,
-          "line": 62
+          "line": 45
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.todoServerInfo",
         "start": {
           "column": 18,
-          "line": 59
+          "line": 42
         }
       },
       {
         "defaultMessage": "!!!Password",
         "end": {
           "column": 3,
-          "line": 66
+          "line": 49
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.lockedPassword",
         "start": {
           "column": 18,
-          "line": 63
+          "line": 46
         }
       },
       {
         "defaultMessage": "!!!Please make sure to set a password you'll remember.\nIf you loose this password, you will have to reinstall Ferdi.",
         "end": {
           "column": 3,
-          "line": 70
+          "line": 53
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.lockedPasswordInfo",
         "start": {
           "column": 22,
-          "line": 67
+          "line": 50
         }
       },
       {
         "defaultMessage": "!!!Password Lock allows you to keep your messages protected.\nUsing Password Lock, you will be prompted to enter your password everytime you start Ferdi or lock Ferdi yourself using the lock symbol in the bottom left corner or the shortcut CMD/CTRL+Shift+L.",
         "end": {
           "column": 3,
-          "line": 74
+          "line": 57
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.lockInfo",
         "start": {
           "column": 12,
-          "line": 71
+          "line": 54
         }
       },
       {
         "defaultMessage": "!!!Times in 24-Hour-Format. End time can be before start time (e.g. start 17:00, end 09:00) to enable Do-not-Disturb overnight.",
         "end": {
           "column": 3,
-          "line": 78
+          "line": 61
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.scheduledDNDTimeInfo",
         "start": {
           "column": 24,
-          "line": 75
+          "line": 58
         }
       },
       {
         "defaultMessage": "!!!Scheduled Do-not-Disturb allows you to define a period of time in which you do not want to get Notifications from Ferdi.",
         "end": {
           "column": 3,
-          "line": 82
+          "line": 65
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.scheduledDNDInfo",
         "start": {
           "column": 20,
-          "line": 79
+          "line": 62
         }
       },
       {
         "defaultMessage": "!!!Language",
         "end": {
           "column": 3,
-          "line": 86
+          "line": 69
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.headlineLanguage",
         "start": {
           "column": 20,
-          "line": 83
+          "line": 66
         }
       },
       {
         "defaultMessage": "!!!Updates",
         "end": {
           "column": 3,
-          "line": 90
+          "line": 73
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.headlineUpdates",
         "start": {
           "column": 19,
-          "line": 87
+          "line": 70
         }
       },
       {
         "defaultMessage": "!!!Appearance",
         "end": {
           "column": 3,
-          "line": 94
+          "line": 77
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.headlineAppearance",
         "start": {
           "column": 22,
-          "line": 91
+          "line": 74
         }
       },
       {
         "defaultMessage": "!!!Universal Dark Mode tries to dynamically generate dark mode styles for services that are otherwise not currently supported.",
         "end": {
           "column": 3,
-          "line": 98
+          "line": 81
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.universalDarkModeInfo",
         "start": {
           "column": 25,
-          "line": 95
+          "line": 78
         }
       },
       {
         "defaultMessage": "!!!Write your accent color in a CSS-compatible format. (Default: #7367f0)",
         "end": {
           "column": 3,
-          "line": 102
+          "line": 85
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.accentColorInfo",
         "start": {
           "column": 19,
-          "line": 99
+          "line": 82
         }
       },
       {
         "defaultMessage": "!!!Advanced",
         "end": {
           "column": 3,
-          "line": 106
+          "line": 89
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.headlineAdvanced",
         "start": {
           "column": 20,
-          "line": 103
+          "line": 86
         }
       },
       {
         "defaultMessage": "!!!Help us to translate Ferdi into your language.",
         "end": {
           "column": 3,
-          "line": 110
+          "line": 93
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.translationHelp",
         "start": {
           "column": 19,
-          "line": 107
+          "line": 90
         }
       },
       {
         "defaultMessage": "!!!Cache",
         "end": {
           "column": 3,
-          "line": 114
+          "line": 97
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.subheadlineCache",
         "start": {
           "column": 20,
-          "line": 111
+          "line": 94
         }
       },
       {
         "defaultMessage": "!!!Ferdi cache is currently using {size} of disk space.",
         "end": {
           "column": 3,
-          "line": 118
+          "line": 101
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.cacheInfo",
         "start": {
           "column": 13,
-          "line": 115
+          "line": 98
         }
       },
       {
         "defaultMessage": "!!!Clear cache",
         "end": {
           "column": 3,
-          "line": 122
+          "line": 105
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.buttonClearAllCache",
         "start": {
           "column": 23,
-          "line": 119
+          "line": 102
         }
       },
       {
         "defaultMessage": "!!!Check for updates",
         "end": {
           "column": 3,
-          "line": 126
+          "line": 109
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.buttonSearchForUpdate",
         "start": {
           "column": 25,
-          "line": 123
+          "line": 106
         }
       },
       {
         "defaultMessage": "!!!Restart & install update",
         "end": {
           "column": 3,
-          "line": 130
+          "line": 113
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.buttonInstallUpdate",
         "start": {
           "column": 23,
-          "line": 127
+          "line": 110
         }
       },
       {
         "defaultMessage": "!!!Is searching for update",
         "end": {
           "column": 3,
-          "line": 134
+          "line": 117
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.updateStatusSearching",
         "start": {
           "column": 25,
-          "line": 131
+          "line": 114
         }
       },
       {
         "defaultMessage": "!!!Update available, downloading...",
         "end": {
           "column": 3,
-          "line": 138
+          "line": 121
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.updateStatusAvailable",
         "start": {
           "column": 25,
-          "line": 135
+          "line": 118
         }
       },
       {
         "defaultMessage": "!!!You are using the latest version of Ferdi",
         "end": {
           "column": 3,
-          "line": 142
+          "line": 125
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.updateStatusUpToDate",
         "start": {
           "column": 24,
-          "line": 139
+          "line": 122
         }
       },
       {
         "defaultMessage": "!!!Current version:",
         "end": {
           "column": 3,
-          "line": 146
+          "line": 129
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.currentVersion",
         "start": {
           "column": 18,
-          "line": 143
+          "line": 126
         }
       },
       {
         "defaultMessage": "!!!Changes require restart",
         "end": {
           "column": 3,
-          "line": 150
+          "line": 133
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.restartRequired",
         "start": {
           "column": 29,
-          "line": 147
+          "line": 130
         }
       },
       {
         "defaultMessage": "!!!Official translations are English & German. All other languages are community based translations.",
         "end": {
           "column": 3,
-          "line": 154
+          "line": 137
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.languageDisclaimer",
         "start": {
           "column": 22,
-          "line": 151
+          "line": 134
         }
       }
     ],

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -324,8 +324,6 @@
   "settings.app.scheduledDNDInfo": "Scheduled Do-not-Disturb allows you to define a period of time in which you do not want to get Notifications from Ferdi.",
   "settings.app.scheduledDNDTimeInfo": "Times in 24-Hour-Format. End time can be before start time (e.g. start 17:00, end 09:00) to enable Do-not-Disturb overnight.",
   "settings.app.sentryInfo": "Sending telemetry data allows us to find errors in Ferdi - we will not send any personal information like your message data! Changing this option requires you to restart Ferdi.",
-  "settings.app.serverInfo": "We advice you to logout after changing your server as your settings might not be saved otherwise.",
-  "settings.app.serverMoneyInfo": "You are using the official Franz Server for Ferdi.\nWe know that Ferdi allows you to use all its features for free but you are still using Franz's server resources - which Franz's creator has to pay for.\nPlease still consider [Link 1]paying for a Franz account[/Link] or [Link 2]using a self-hosted ferdi-server[/Link] (if you have the knowledge and resources to do so). \nBy using Ferdi, you still profit greatly from Franz's recipe store, server resources and its development.",
   "settings.app.subheadlineCache": "Cache",
   "settings.app.todoServerInfo": "This server will be used for the \"Ferdi Todo\" feature. (default: https://app.franztodos.com)",
   "settings.app.translationHelp": "Help us to translate Ferdi into your language.",

--- a/src/i18n/messages/src/components/settings/settings/EditSettingsForm.json
+++ b/src/i18n/messages/src/components/settings/settings/EditSettingsForm.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Settings",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 31,
+      "line": 22,
       "column": 12
     },
     "end": {
-      "line": 34,
+      "line": 25,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!General",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 35,
+      "line": 26,
       "column": 19
     },
     "end": {
-      "line": 38,
+      "line": 29,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Sending telemetry data allows us to find errors in Ferdi - we will not send any personal information like your message data! Changing this option requires you to restart Ferdi.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 39,
+      "line": 30,
       "column": 14
     },
     "end": {
-      "line": 42,
+      "line": 33,
       "column": 3
     }
   },
@@ -43,11 +43,11 @@
     "defaultMessage": "!!!By default, Ferdi will keep all your services open and loaded in the background so they are ready when you want to use them. Service Hibernation will unload your services after a specified amount. This is useful to save RAM or keeping services from slowing down your computer.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 43,
+      "line": 34,
       "column": 17
     },
     "end": {
-      "line": 46,
+      "line": 37,
       "column": 3
     }
   },
@@ -56,37 +56,11 @@
     "defaultMessage": "!!!Minutes of inactivity, after which Ferdi should automatically lock. Use 0 to disable",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 47,
+      "line": 38,
       "column": 22
     },
     "end": {
-      "line": 50,
-      "column": 3
-    }
-  },
-  {
-    "id": "settings.app.serverInfo",
-    "defaultMessage": "!!!We advice you to logout after changing your server as your settings might not be saved otherwise.",
-    "file": "src/components/settings/settings/EditSettingsForm.js",
-    "start": {
-      "line": 51,
-      "column": 14
-    },
-    "end": {
-      "line": 54,
-      "column": 3
-    }
-  },
-  {
-    "id": "settings.app.serverMoneyInfo",
-    "defaultMessage": "!!!You are using the official Franz Server for Ferdi.\nWe know that Ferdi allows you to use all its features for free but you are still using Franz's server resources - which Franz's creator has to pay for.\nPlease still consider [Link 1]paying for a Franz account[/Link] or [Link 2]using a self-hosted ferdi-server[/Link] (if you have the knowledge and resources to do so). \nBy using Ferdi, you still profit greatly from Franz's recipe store, server resources and its development.",
-    "file": "src/components/settings/settings/EditSettingsForm.js",
-    "start": {
-      "line": 55,
-      "column": 19
-    },
-    "end": {
-      "line": 58,
+      "line": 41,
       "column": 3
     }
   },
@@ -95,11 +69,11 @@
     "defaultMessage": "!!!This server will be used for the \"Franz Todo\" feature. (default: https://app.franztodos.com)",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 59,
+      "line": 42,
       "column": 18
     },
     "end": {
-      "line": 62,
+      "line": 45,
       "column": 3
     }
   },
@@ -108,11 +82,11 @@
     "defaultMessage": "!!!Password",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 63,
+      "line": 46,
       "column": 18
     },
     "end": {
-      "line": 66,
+      "line": 49,
       "column": 3
     }
   },
@@ -121,11 +95,11 @@
     "defaultMessage": "!!!Please make sure to set a password you'll remember.\nIf you loose this password, you will have to reinstall Ferdi.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 67,
+      "line": 50,
       "column": 22
     },
     "end": {
-      "line": 70,
+      "line": 53,
       "column": 3
     }
   },
@@ -134,11 +108,11 @@
     "defaultMessage": "!!!Password Lock allows you to keep your messages protected.\nUsing Password Lock, you will be prompted to enter your password everytime you start Ferdi or lock Ferdi yourself using the lock symbol in the bottom left corner or the shortcut CMD/CTRL+Shift+L.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 71,
+      "line": 54,
       "column": 12
     },
     "end": {
-      "line": 74,
+      "line": 57,
       "column": 3
     }
   },
@@ -147,11 +121,11 @@
     "defaultMessage": "!!!Times in 24-Hour-Format. End time can be before start time (e.g. start 17:00, end 09:00) to enable Do-not-Disturb overnight.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 75,
+      "line": 58,
       "column": 24
     },
     "end": {
-      "line": 78,
+      "line": 61,
       "column": 3
     }
   },
@@ -160,11 +134,11 @@
     "defaultMessage": "!!!Scheduled Do-not-Disturb allows you to define a period of time in which you do not want to get Notifications from Ferdi.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 79,
+      "line": 62,
       "column": 20
     },
     "end": {
-      "line": 82,
+      "line": 65,
       "column": 3
     }
   },
@@ -173,11 +147,11 @@
     "defaultMessage": "!!!Language",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 83,
+      "line": 66,
       "column": 20
     },
     "end": {
-      "line": 86,
+      "line": 69,
       "column": 3
     }
   },
@@ -186,11 +160,11 @@
     "defaultMessage": "!!!Updates",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 87,
+      "line": 70,
       "column": 19
     },
     "end": {
-      "line": 90,
+      "line": 73,
       "column": 3
     }
   },
@@ -199,11 +173,11 @@
     "defaultMessage": "!!!Appearance",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 91,
+      "line": 74,
       "column": 22
     },
     "end": {
-      "line": 94,
+      "line": 77,
       "column": 3
     }
   },
@@ -212,11 +186,11 @@
     "defaultMessage": "!!!Universal Dark Mode tries to dynamically generate dark mode styles for services that are otherwise not currently supported.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 95,
+      "line": 78,
       "column": 25
     },
     "end": {
-      "line": 98,
+      "line": 81,
       "column": 3
     }
   },
@@ -225,11 +199,11 @@
     "defaultMessage": "!!!Write your accent color in a CSS-compatible format. (Default: #7367f0)",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 99,
+      "line": 82,
       "column": 19
     },
     "end": {
-      "line": 102,
+      "line": 85,
       "column": 3
     }
   },
@@ -238,11 +212,11 @@
     "defaultMessage": "!!!Advanced",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 103,
+      "line": 86,
       "column": 20
     },
     "end": {
-      "line": 106,
+      "line": 89,
       "column": 3
     }
   },
@@ -251,11 +225,11 @@
     "defaultMessage": "!!!Help us to translate Ferdi into your language.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 107,
+      "line": 90,
       "column": 19
     },
     "end": {
-      "line": 110,
+      "line": 93,
       "column": 3
     }
   },
@@ -264,11 +238,11 @@
     "defaultMessage": "!!!Cache",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 111,
+      "line": 94,
       "column": 20
     },
     "end": {
-      "line": 114,
+      "line": 97,
       "column": 3
     }
   },
@@ -277,11 +251,11 @@
     "defaultMessage": "!!!Ferdi cache is currently using {size} of disk space.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 115,
+      "line": 98,
       "column": 13
     },
     "end": {
-      "line": 118,
+      "line": 101,
       "column": 3
     }
   },
@@ -290,11 +264,11 @@
     "defaultMessage": "!!!Clear cache",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 119,
+      "line": 102,
       "column": 23
     },
     "end": {
-      "line": 122,
+      "line": 105,
       "column": 3
     }
   },
@@ -303,11 +277,11 @@
     "defaultMessage": "!!!Check for updates",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 123,
+      "line": 106,
       "column": 25
     },
     "end": {
-      "line": 126,
+      "line": 109,
       "column": 3
     }
   },
@@ -316,11 +290,11 @@
     "defaultMessage": "!!!Restart & install update",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 127,
+      "line": 110,
       "column": 23
     },
     "end": {
-      "line": 130,
+      "line": 113,
       "column": 3
     }
   },
@@ -329,11 +303,11 @@
     "defaultMessage": "!!!Is searching for update",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 131,
+      "line": 114,
       "column": 25
     },
     "end": {
-      "line": 134,
+      "line": 117,
       "column": 3
     }
   },
@@ -342,11 +316,11 @@
     "defaultMessage": "!!!Update available, downloading...",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 135,
+      "line": 118,
       "column": 25
     },
     "end": {
-      "line": 138,
+      "line": 121,
       "column": 3
     }
   },
@@ -355,11 +329,11 @@
     "defaultMessage": "!!!You are using the latest version of Ferdi",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 139,
+      "line": 122,
       "column": 24
     },
     "end": {
-      "line": 142,
+      "line": 125,
       "column": 3
     }
   },
@@ -368,11 +342,11 @@
     "defaultMessage": "!!!Current version:",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 143,
+      "line": 126,
       "column": 18
     },
     "end": {
-      "line": 146,
+      "line": 129,
       "column": 3
     }
   },
@@ -381,11 +355,11 @@
     "defaultMessage": "!!!Changes require restart",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 147,
+      "line": 130,
       "column": 29
     },
     "end": {
-      "line": 150,
+      "line": 133,
       "column": 3
     }
   },
@@ -394,11 +368,11 @@
     "defaultMessage": "!!!Official translations are English & German. All other languages are community based translations.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 151,
+      "line": 134,
       "column": 22
     },
     "end": {
-      "line": 154,
+      "line": 137,
       "column": 3
     }
   }

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -156,12 +156,12 @@
     }
   },
   {
-    "id": "settings.app.form.server",
-    "defaultMessage": "!!!Server",
+    "id": "settings.app.form.todoServer",
+    "defaultMessage": "!!!Todo Server",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 79,
-      "column": 10
+      "column": 14
     },
     "end": {
       "line": 82,
@@ -169,8 +169,8 @@
     }
   },
   {
-    "id": "settings.app.form.todoServer",
-    "defaultMessage": "!!!Todo Server",
+    "id": "settings.app.form.enableLock",
+    "defaultMessage": "!!!Enable Password Lock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 83,
@@ -182,28 +182,15 @@
     }
   },
   {
-    "id": "settings.app.form.enableLock",
-    "defaultMessage": "!!!Enable Password Lock",
-    "file": "src/containers/settings/EditSettingsScreen.js",
-    "start": {
-      "line": 87,
-      "column": 14
-    },
-    "end": {
-      "line": 90,
-      "column": 3
-    }
-  },
-  {
     "id": "settings.app.form.lockPassword",
     "defaultMessage": "!!!Password",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 91,
+      "line": 87,
       "column": 16
     },
     "end": {
-      "line": 94,
+      "line": 90,
       "column": 3
     }
   },
@@ -212,11 +199,11 @@
     "defaultMessage": "!!!Allow using Touch ID to unlock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 95,
+      "line": 91,
       "column": 22
     },
     "end": {
-      "line": 98,
+      "line": 94,
       "column": 3
     }
   },
@@ -225,11 +212,11 @@
     "defaultMessage": "!!!Lock after inactivity",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 99,
+      "line": 95,
       "column": 18
     },
     "end": {
-      "line": 102,
+      "line": 98,
       "column": 3
     }
   },
@@ -238,11 +225,11 @@
     "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 103,
+      "line": 99,
       "column": 23
     },
     "end": {
-      "line": 106,
+      "line": 102,
       "column": 3
     }
   },
@@ -251,11 +238,11 @@
     "defaultMessage": "!!!From",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 107,
+      "line": 103,
       "column": 21
     },
     "end": {
-      "line": 110,
+      "line": 106,
       "column": 3
     }
   },
@@ -264,8 +251,21 @@
     "defaultMessage": "!!!To",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 111,
+      "line": 107,
       "column": 19
+    },
+    "end": {
+      "line": 110,
+      "column": 3
+    }
+  },
+  {
+    "id": "settings.app.form.language",
+    "defaultMessage": "!!!Language",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 111,
+      "column": 12
     },
     "end": {
       "line": 114,
@@ -273,8 +273,8 @@
     }
   },
   {
-    "id": "settings.app.form.language",
-    "defaultMessage": "!!!Language",
+    "id": "settings.app.form.darkMode",
+    "defaultMessage": "!!!Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 115,
@@ -286,12 +286,12 @@
     }
   },
   {
-    "id": "settings.app.form.darkMode",
-    "defaultMessage": "!!!Dark Mode",
+    "id": "settings.app.form.adaptableDarkMode",
+    "defaultMessage": "!!!Synchronize dark mode with my Mac's dark mode setting",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 119,
-      "column": 12
+      "column": 21
     },
     "end": {
       "line": 122,
@@ -299,8 +299,8 @@
     }
   },
   {
-    "id": "settings.app.form.adaptableDarkMode",
-    "defaultMessage": "!!!Synchronize dark mode with my Mac's dark mode setting",
+    "id": "settings.app.form.universalDarkMode",
+    "defaultMessage": "!!!Enable universal Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 123,
@@ -312,28 +312,15 @@
     }
   },
   {
-    "id": "settings.app.form.universalDarkMode",
-    "defaultMessage": "!!!Enable universal Dark Mode",
-    "file": "src/containers/settings/EditSettingsScreen.js",
-    "start": {
-      "line": 127,
-      "column": 21
-    },
-    "end": {
-      "line": 130,
-      "column": 3
-    }
-  },
-  {
     "id": "settings.app.form.serviceRibbonWidth",
     "defaultMessage": "!!!Sidebar width",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 131,
+      "line": 127,
       "column": 22
     },
     "end": {
-      "line": 134,
+      "line": 130,
       "column": 3
     }
   },
@@ -342,11 +329,11 @@
     "defaultMessage": "!!!Service icon size",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 135,
+      "line": 131,
       "column": 12
     },
     "end": {
-      "line": 138,
+      "line": 134,
       "column": 3
     }
   },
@@ -355,11 +342,11 @@
     "defaultMessage": "!!!Accent color",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 139,
+      "line": 135,
       "column": 15
     },
     "end": {
-      "line": 142,
+      "line": 138,
       "column": 3
     }
   },
@@ -368,11 +355,11 @@
     "defaultMessage": "!!!Display disabled services tabs",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 143,
+      "line": 139,
       "column": 24
     },
     "end": {
-      "line": 146,
+      "line": 142,
       "column": 3
     }
   },
@@ -381,11 +368,11 @@
     "defaultMessage": "!!!Show unread message badge when notifications are disabled",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 147,
+      "line": 143,
       "column": 29
     },
     "end": {
-      "line": 150,
+      "line": 146,
       "column": 3
     }
   },
@@ -394,11 +381,11 @@
     "defaultMessage": "!!!Enable spell checking",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 151,
+      "line": 147,
       "column": 23
     },
     "end": {
-      "line": 154,
+      "line": 150,
       "column": 3
     }
   },
@@ -407,11 +394,11 @@
     "defaultMessage": "!!!Enable GPU Acceleration",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 155,
+      "line": 151,
       "column": 25
     },
     "end": {
-      "line": 158,
+      "line": 154,
       "column": 3
     }
   },
@@ -420,11 +407,11 @@
     "defaultMessage": "!!!Include beta versions",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 159,
+      "line": 155,
       "column": 8
     },
     "end": {
-      "line": 162,
+      "line": 158,
       "column": 3
     }
   },
@@ -433,11 +420,11 @@
     "defaultMessage": "!!!Disable updates",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 163,
+      "line": 159,
       "column": 13
     },
     "end": {
-      "line": 166,
+      "line": 162,
       "column": 3
     }
   },
@@ -446,11 +433,11 @@
     "defaultMessage": "!!!Enable Franz Todos",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 167,
+      "line": 163,
       "column": 15
     },
     "end": {
-      "line": 170,
+      "line": 166,
       "column": 3
     }
   },
@@ -459,11 +446,11 @@
     "defaultMessage": "!!!Keep all workspaces loaded",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 171,
+      "line": 167,
       "column": 27
     },
     "end": {
-      "line": 174,
+      "line": 170,
       "column": 3
     }
   }


### PR DESCRIPTION
### Description

### Motivation and Context
This is the first PR (w/ help from @kytwb) 
- Remove the Server settings in the Settings screen as it doesn't make sense anymore as per #510 

### How Has This Been Tested?
Locally.

### Screenshots (if appropriate):

BEFORE
<img width="458" alt="Screen Shot 2020-03-29 at 12 37 16 PM" src="https://user-images.githubusercontent.com/25288435/77848079-0c279d80-71ba-11ea-984e-3cb84995b682.png">

AFTER
<img width="458" alt="Screen Shot 2020-03-29 at 12 49 54 PM" src="https://user-images.githubusercontent.com/25288435/77848322-d1bf0000-71bb-11ea-8421-2d4987ed4121.png">

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [x] My code follows the code style of this project (run `$ yarn lint`).
