### PR TITLE
Update stale bot configuration

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -18,8 +18,9 @@ staleLabel: "[Status] Stale"
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+  recent activity. Please check if this issue is still relevant and please close it if it's not.
+  This will make sure that our open issues are actually of use and reduce the list of obsolete issues.
+  Thank you for your contributions.
   
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -11,7 +11,6 @@ daysUntilClose: -1 # Close the issue almost immediately. See: https://github.com
 exemptLabels:
   - blocker
   - security
-  - bug
   
 # Label to use when marking an issue as stale
 staleLabel: "[Status] Stale"

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 365 # 1 year
+daysUntilStale: 60
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
@@ -11,7 +11,6 @@ daysUntilClose: -1 # Close the issue almost immediately. See: https://github.com
 exemptLabels:
   - blocker
   - security
-  - feature request
   - bug
   
 # Label to use when marking an issue as stale


### PR DESCRIPTION
The current Stale Bot configuration is very weak - only issues that are not labeled "bug" or "feature request" get closed after 1 year of inactivity.
We recently crossed 100 open issues with many stale feature requests and other issues that are not of use anymore.
This PR will change the Stale Bot configuration to mark these issues as "Stale" sooner. It **does not close** them but only mark them as so we can better filter out which issues and feature requests are actually important.