### PR TITLE
Update Stalebot configuration to not close stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,7 @@ daysUntilStale: 60
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: -1 # Close the issue almost immediately. See: https://github.com/probot/stale/issues/131
+daysUntilClose: 999999
 
 # Issues with these labels will never be considered stale
 exemptLabels:


### PR DESCRIPTION
This PR will update the Stalebot config to not close any stale issues - we'll change to the more elegant "-1" solution once the PR for that is merged.

I'll re-open the closed issues once this PR is merged.