### PR TITLE
Fix cache clearing not working in Windows 10 (#541)

### DIFF
--- a/src/api/LocalApi.js
+++ b/src/api/LocalApi.js
@@ -16,7 +16,7 @@ export default class LocalApi {
     return this.local.getAppCacheSize();
   }
 
-  clearAppCache() {
-    return this.local.clearAppCache();
+  clearCache() {
+    return this.local.clearCache();
   }
 }

--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -41,7 +41,7 @@ export default class LocalApi {
     });
   }
 
-  async clearCache(serviceId) {
+  async clearCache(serviceId = null) {
     const s = serviceId ? session.fromPartition(`persist:service-${serviceId}`) : session.defaultSession;
 
     debug('LocalApi::clearCache resolves', (serviceId || 'clearAppCache'));
@@ -50,9 +50,5 @@ export default class LocalApi {
       quotas: ['temporary', 'persistent', 'syncable'],
     });
     return s.clearCache();
-  }
-
-  async clearAppCache() {
-    return this.clearCache();
   }
 }

--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -45,6 +45,10 @@ export default class LocalApi {
     const s = session.fromPartition(`persist:service-${serviceId}`);
 
     debug('LocalApi::clearCache resolves', serviceId);
+    await s.clearStorageData({
+      storages: ['appcache', 'cookies', 'filesystem', 'indexdb', 'localstorage', 'shadercache', 'websql', 'serviceworkers', 'cachestorage'],
+      quotas: ['temporary', 'persistent', 'syncable']                
+    });
     return s.clearCache();
   }
 
@@ -52,6 +56,10 @@ export default class LocalApi {
     const s = session.defaultSession;
 
     debug('LocalApi::clearCache clearAppCache');
+    await s.clearStorageData({
+      storages: ['appcache', 'cookies', 'filesystem', 'indexdb', 'localstorage', 'shadercache', 'websql', 'serviceworkers', 'cachestorage'],
+      quotas: ['temporary', 'persistent', 'syncable']                
+    });
     return s.clearCache();
   }
 }

--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -42,24 +42,17 @@ export default class LocalApi {
   }
 
   async clearCache(serviceId) {
-    const s = session.fromPartition(`persist:service-${serviceId}`);
+    const s = serviceId ? session.fromPartition(`persist:service-${serviceId}`) : session.defaultSession;
 
-    debug('LocalApi::clearCache resolves', serviceId);
+    debug('LocalApi::clearCache resolves', (serviceId || 'clearAppCache'));
     await s.clearStorageData({
       storages: ['appcache', 'cookies', 'filesystem', 'indexdb', 'localstorage', 'shadercache', 'websql', 'serviceworkers', 'cachestorage'],
-      quotas: ['temporary', 'persistent', 'syncable']                
+      quotas: ['temporary', 'persistent', 'syncable'],
     });
     return s.clearCache();
   }
 
   async clearAppCache() {
-    const s = session.defaultSession;
-
-    debug('LocalApi::clearCache clearAppCache');
-    await s.clearStorageData({
-      storages: ['appcache', 'cookies', 'filesystem', 'indexdb', 'localstorage', 'shadercache', 'websql', 'serviceworkers', 'cachestorage'],
-      quotas: ['temporary', 'persistent', 'syncable']                
-    });
-    return s.clearCache();
+    return this.clearCache();
   }
 }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -52,7 +52,7 @@ export default class AppStore extends Store {
 
   @observable getAppCacheSizeRequest = new Request(this.api.local, 'getAppCacheSize');
 
-  @observable clearAppCacheRequest = new Request(this.api.local, 'clearAppCache');
+  @observable clearAppCacheRequest = new Request(this.api.local, 'clearCache');
 
   @observable autoLaunchOnStart = true;
 

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -374,8 +374,11 @@ export default class AppStore extends Store {
     const allServiceIds = await getServiceIdsFromPartitions();
     const allOrphanedServiceIds = allServiceIds.filter(id => !this.stores.services.all.find(s => id.replace('service-', '') === s.id));
 
-    await Promise.all(allOrphanedServiceIds.map(id => removeServicePartitionDirectory(id)));
-
+    try {
+      await Promise.all(allOrphanedServiceIds.map(id => removeServicePartitionDirectory(id)));
+    } catch (ex) {
+      console.log('Error while deleting service partition directory - ', ex);
+    }
     await Promise.all(this.stores.services.all.map(s => this.actions.service.clearCache({ serviceId: s.id })));
 
     await clearAppCache._promise;


### PR DESCRIPTION

Clear Cache under settings spins indefinitely and does not clear any service data which is held in session partitions.
<!--- Provide a general summary of your changes in the Title above -->

### Description

  - In AppStore, the partition directory of allorphanedserviceIds are attempted to be removed during clear cache. However, atleast in Windows, certain files like Cookies, indexedDB and other autogenerated ones during session creation are locked and hence fs.removeDirectory throws an exception. I have added a try catch around this piece of code to avoid uncaught exceptions which causes the spinner to spin indefnitely and prevents execution of further code
  - From electron docs - I found that calling session.clearstorage([options]) is a better way to clear session storage data. Hence, in LocalApi.js, we are clearing out all possible storages and quotas of all services and the default session. More info in this [link](https://www.electronjs.org/docs/api/session#sesclearstoragedataoptions)

### Motivation and Context
This PR is to address #541 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
1. Add several service accounts after choosing a ferdi server
2. Make sure we have some cache data
3. Goto settings-> Clear cache. Make sure that clear cache doesnt spin indefnitely. Monitor console logs. 
4. Evaluate the cache size after clearing. It will have come down significantly. We cannot delete certain files and folders that are still under use as they will be locked.
<!--- Include details of your testing environment, tests ran to see how -->
Env: Windows 10
Development Mode

### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1255523/78665090-e3f31980-78f2-11ea-8e25-431e3969254e.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
