### PR TITLE
Add support for Adaptable Dark Mode on Windows

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -12,7 +12,7 @@ import PremiumFeatureContainer from '../../ui/PremiumFeatureContainer';
 import Input from '../../ui/Input';
 
 import { FRANZ_TRANSLATION } from '../../../config';
-import { isMac } from '../../../environment';
+import { isMac, isWindows } from '../../../environment';
 
 const {
   systemPreferences,
@@ -405,8 +405,8 @@ export default @observer class EditSettingsForm extends Component {
 
             <Hr />
 
-            {isMac && <Toggle field={form.$('adaptableDarkMode')} />}
-            {!(isMac && isAdaptableDarkModeEnabled) && <Toggle field={form.$('darkMode')} />}
+            {(isMac || isWindows) && <Toggle field={form.$('adaptableDarkMode')} />}
+            {!((isMac || isWindows) && isAdaptableDarkModeEnabled) && <Toggle field={form.$('darkMode')} />}
             {(isDarkmodeEnabled || isAdaptableDarkModeEnabled) && (
               <>
                 <Toggle field={form.$('universalDarkMode')} />
@@ -530,9 +530,11 @@ export default @observer class EditSettingsForm extends Component {
 
               <span className="mdi mdi-github-face" />
               <span>
+
                 Ferdi is based on
                 {' '}
                 <a href="https://github.com/meetfranz/franz" target="_blank">Franz</a>
+
                 , a project published
                 under the
                 {' '}

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -120,7 +120,7 @@ const messages = defineMessages({
   },
   adaptableDarkMode: {
     id: 'settings.app.form.adaptableDarkMode',
-    defaultMessage: '!!!Synchronize dark mode with my Mac\'s dark mode setting',
+    defaultMessage: '!!!Synchronize dark mode with my OS\'s dark mode setting',
   },
   universalDarkMode: {
     id: 'settings.app.form.universalDarkMode',

--- a/src/i18n/locales/af.json
+++ b/src/i18n/locales/af.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/bs.json
+++ b/src/i18n/locales/bs.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "La memòria cau de Ferdi està utilitzant {size} d'espai al disc",
   "settings.app.currentVersion": "Versió actual:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Obrir en segon plà",
   "settings.app.form.autoLaunchOnStart": "Iniciar Ferdi a l'inici",
   "settings.app.form.beta": "Inclou versions beta",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi momentálně používá {size} místa na disku.",
   "settings.app.currentVersion": "Aktuální verze:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Spustit na pozadí",
   "settings.app.form.autoLaunchOnStart": "Spustit Ferdi při startu",
   "settings.app.form.beta": "Zahrnout beta verze",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -4479,7 +4479,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Synchronize dark mode with my Mac's dark mode setting",
+        "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
         "end": {
           "column": 3,
           "line": 124

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Το Ferdi χρησιμοποιεί αυτήν τη στιγμή {size} χώρου στο δίσκο.",
   "settings.app.currentVersion": "Τρέχουσα έκδοση:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Άνοιγμα στο παρασκήνιο",
   "settings.app.form.autoLaunchOnStart": "Εκκίνηση του Ferdi κατά την εκκίνηση του συστήματος",
   "settings.app.form.beta": "Συμπεριλάβετε εκδόσεις beta",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -274,7 +274,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -219,6 +219,7 @@
   "settings.app.cacheInfo": "Tá taisce Ferdi ag baint úsáid as {size} den spás diosca.",
   "settings.app.currentVersion": "Leagan reatha:",
   "settings.app.form.autoLaunchInBackground": "Oscail sa chúlra",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchOnStart": "Láinseáil Ferdi ón tús",
   "settings.app.form.beta": "Cuir leagain béite san áireamh",
   "settings.app.form.darkMode": "Join the Dark Side",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "El cache de Ferdi actualmente usa {size} de espacio en disco.",
   "settings.app.currentVersion": "Versión actual:",
   "settings.app.form.accentColor": "Color de realce",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Abrir en segundo plano",
   "settings.app.form.autoLaunchOnStart": "Iniciar Ferdi al iniciar",
   "settings.app.form.beta": "Incluir versiones beta",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Tá taisce Ferdi ag baint úsáid as {size} den spás diosca.",
   "settings.app.currentVersion": "Leagan reatha:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Oscail sa chúlra",
   "settings.app.form.autoLaunchOnStart": "Láinseáil Ferdi ón tús",
   "settings.app.form.beta": "Cuir leagain béite san áireamh",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi predmemorija trenutno koristi {size} prostora na disku",
   "settings.app.currentVersion": "Trenutna verzija:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Otvori u pozadini",
   "settings.app.form.autoLaunchOnStart": "Pokreni Ferdi sa sistemom",
   "settings.app.form.beta": "Obuhvati i beta verzije",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "A Ferdi gyorsítótár jelenleg {size} lemezterületet használ.",
   "settings.app.currentVersion": "Aktuális verzió:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Megnyitás háttérben",
   "settings.app.form.autoLaunchOnStart": "Ferdi betöltése indításkor",
   "settings.app.form.beta": "Béta verziók keresése",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Singgahan Ferdi sedang menggunakan ruang disk {size}.",
   "settings.app.currentVersion": "Versi saat ini:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Buka di latar belakang",
   "settings.app.form.autoLaunchOnStart": "Jalankan Ferdi saat komputer dimulai",
   "settings.app.form.beta": "Sertakan versi beta",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi sta utilizzando {size} di spazio su disco.",
   "settings.app.currentVersion": "Versione attuale:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Apri in background",
   "settings.app.form.autoLaunchOnStart": "Esegui Ferdi all'avvio",
   "settings.app.form.beta": "Includi versioni beta",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "現在、Ferdiのキャッシュはディスクの{size}分を使用しています。",
   "settings.app.currentVersion": "現在のバージョン:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "バックグラウンドで開く",
   "settings.app.form.autoLaunchOnStart": "システム起動時にFerdiを開く",
   "settings.app.form.beta": "Betaバージョンを含める",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "ამჟამინდელი ვერსია:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "გახსენით ფონზე",
   "settings.app.form.autoLaunchOnStart": "გაეშვას Ferdi სისტემის ჩატვირთვისას",
   "settings.app.form.beta": "ჩართეთ ბეტა ვერსიები",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/nl-BE.json
+++ b/src/i18n/locales/nl-BE.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache gebruikt momenteel {size} schijfruimte.",
   "settings.app.currentVersion": "Huidige versie:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open op de achtergrond",
   "settings.app.form.autoLaunchOnStart": "Lanceer Ferdi bij opstarten",
   "settings.app.form.beta": "Inclusief beta versies",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi gebruikt op dit moment {size} schijfruimte aan tijdelijke bestanden.",
   "settings.app.currentVersion": "Huidige versie:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open op de achtergrond",
   "settings.app.form.autoLaunchOnStart": "Open Ferdi bij opstarten",
   "settings.app.form.beta": "Inclusief bètaversies",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Pamięć podręczna zajmuje obecnie {size} przestrzeni dyskowej",
   "settings.app.currentVersion": "Aktualna wersja:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Otwórz w tle",
   "settings.app.form.autoLaunchOnStart": "Uruchom Ferdi na początku",
   "settings.app.form.beta": "Uwzględnij wersje beta",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "O cache do Ferdi está usando {size} de espaço em disco atualmente.",
   "settings.app.currentVersion": "Versão atual:",
   "settings.app.form.accentColor": "Cor de destaque",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Abrir em segundo plano",
   "settings.app.form.autoLaunchOnStart": "Abrir o Ferdi ao iniciar o sistema",
   "settings.app.form.beta": "Incluir versões beta",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Кэш занимает {size} на диске.",
   "settings.app.currentVersion": "Текущая версия:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Открывать в фоне",
   "settings.app.form.autoLaunchOnStart": "Запускать Ferdi при старте",
   "settings.app.form.beta": "Включая бета версии",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Vyrovnávacia pamäť Ferdi momentálne používa {size} miesta na disku.",
   "settings.app.currentVersion": "Súčasná verzia:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Otvoriť na pozadí",
   "settings.app.form.autoLaunchOnStart": "Spustiť Ferdi pri štarte",
   "settings.app.form.beta": "Vrátane beta verzií",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Франз кеш тренутно користи {size} простора на диску.",
   "settings.app.currentVersion": "Trenutna verzija:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Otvori u pozadini",
   "settings.app.form.autoLaunchOnStart": "Pokreni Ferdi sa sistemom",
   "settings.app.form.beta": "Obuhvati i beta verzije",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Nuvarande version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Öppna i bakgrunden",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi önbelleği şu anda {size} disk alanı kullanıyor.",
   "settings.app.currentVersion": "Geçerli sürüm:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Arka planda aç",
   "settings.app.form.autoLaunchOnStart": "Ferdi'ı başlangıçta aç",
   "settings.app.form.beta": "Beta versiyonları dahil et",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Кеш, який використовує Ferdi, займає {size} дискового простору.",
   "settings.app.currentVersion": "Поточна версія:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Відкрити у фоновому режимі",
   "settings.app.form.autoLaunchOnStart": "Запускати Ferdi на початку",
   "settings.app.form.beta": "Включити бета-версії",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -266,7 +266,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",

--- a/src/i18n/locales/zh-HANT.json
+++ b/src/i18n/locales/zh-HANT.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "當前版本：",
   "settings.app.form.accentColor": "強調顏色",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "背景啟動",
   "settings.app.form.autoLaunchOnStart": "開機時啟動",
   "settings.app.form.beta": "包含開發中版本",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -270,7 +270,7 @@
   "settings.app.cacheInfo": "Ferdi cache is currently using {size} of disk space.",
   "settings.app.currentVersion": "Current version:",
   "settings.app.form.accentColor": "Accent color",
-  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my Mac's dark mode setting",
+  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting",
   "settings.app.form.autoLaunchInBackground": "Open in background",
   "settings.app.form.autoLaunchOnStart": "Launch Ferdi on start",
   "settings.app.form.beta": "Include beta versions",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Automatically switch from Normal Mode -> Dark Mode and vice versa based on Windows 10's dark mode settings

### Description

  - Add support for making adaptable checkbox visible for Windows
  - Add support in UIStore to check for theme updated using the nativeTheme.on('update', () => {}) event and update the darkmode properties accordinly.
  - Update intl to change text to a more generic wording -  "settings.app.form.adaptableDarkMode": "Synchronize dark mode with my OS's dark mode setting"

### Motivation and Context
<!--- If it fixes an open issue, please link to the issue here. -->
This feature is to provide support described in #481 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested manually on windows 10. Went to system settings and switched between dark mode and light mode and observed the changes in ferdi app. Made sure that ferdi changed from dark mode to light mode.
<!--- Include details of your testing environment, tests ran to see how -->
Windows 10, Development mode of Ferdi
<!--- your change affects other areas of the code, etc. -->

### Screenshots (if appropriate):
With Light Mode in Windows

![image](https://user-images.githubusercontent.com/1255523/78799750-322e1880-79d8-11ea-8578-e569c72929c1.png)

With Dark Mode in Windows

![image](https://user-images.githubusercontent.com/1255523/78799803-470aac00-79d8-11ea-86db-9c6b50f9a171.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
