### PR TITLE
Improve user scripts

### DIFF
--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -351,7 +351,18 @@ export default class ServicesStore extends Store {
 
     // Create and open file
     const filePath = path.join(directory, file);
-    await fs.ensureFile(filePath);
+    if (file === 'user.js') {
+      if (!await fs.exists(filePath)) {
+        await fs.writeFile(filePath, `
+module.exports = (config, Ferdi) => {
+  // Write your scripts here
+  console.log("Hello, World!", config);
+}
+`);
+      }
+    } else {
+      await fs.ensureFile(filePath);
+    }
     shell.showItemInFolder(filePath);
   }
 

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -353,8 +353,7 @@ export default class ServicesStore extends Store {
     const filePath = path.join(directory, file);
     if (file === 'user.js') {
       if (!await fs.exists(filePath)) {
-        await fs.writeFile(filePath, `
-module.exports = (config, Ferdi) => {
+        await fs.writeFile(filePath, `module.exports = (config, Ferdi) => {
   // Write your scripts here
   console.log("Hello, World!", config);
 }

--- a/src/webview/lib/Userscript.js
+++ b/src/webview/lib/Userscript.js
@@ -123,8 +123,8 @@ export default class Userscript {
 
   /**
    * Open a URL in the current service
-   * 
-   * @param {*} url 
+   *
+   * @param {*} url
    */
   internalOpen(url) {
     window.location.href = url;

--- a/src/webview/lib/Userscript.js
+++ b/src/webview/lib/Userscript.js
@@ -1,0 +1,123 @@
+import { ipcRenderer } from 'electron';
+
+export default class Userscript {
+  // Current ./lib/RecipeWebview instance
+  recipe = null;
+
+  // Current ./recipe.js instance
+  controller = null;
+
+  // Service configuration
+  config = {};
+
+  // Ferdi and service settings
+  settings = {};
+
+  settingsUpdateHandler = null;
+
+  constructor(recipe, controller, config) {
+    this.recipe = recipe;
+    this.controller = controller;
+    this.internal_setSettings(controller.settings);
+    this.config = config;
+  }
+
+  /**
+   * Set internal copy of Ferdi's settings.
+   * This is only used internally and can not be used to change any settings
+   *
+   * @param {*} settings
+   */
+  // eslint-disable-next-line
+  internal_setSettings(settings) {
+    // This is needed to get a clean JS object from the settings itself to provide better accessibility
+    // Otherwise this will be a mobX instance
+    this.settings = JSON.parse(JSON.stringify(settings));
+
+    if (typeof this.settingsUpdateHandler === 'function') {
+      this.settingsUpdateHandler();
+    }
+  }
+
+  /**
+   * Register a settings handler to be executed when the settings change
+   *
+   * @param {function} handler
+   */
+  onSettingsUpdate(handler) {
+    this.settingsUpdateHandler = handler;
+  }
+
+  /**
+   * Set badge count for the current service
+   * @param {*} direct Direct messages
+   * @param {*} indirect Indirect messages
+   */
+  setBadge(direct = 0, indirect = 0) {
+    if (this.recipe && this.recipe.setBadge) {
+      this.recipe.setBadge(direct, indirect);
+    }
+  }
+
+  /**
+   * Inject CSS files into the current page
+   *
+   * @param  {...string} files
+   */
+  injectCSSFiles(...files) {
+    if (this.recipe && this.recipe.injectCSS) {
+      this.recipe.injectCSS(...files);
+    }
+  }
+
+  /**
+   * Inject a CSS string into the page
+   *
+   * @param {string} css
+   */
+  injectCSS(css) {
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.append(style);
+  }
+
+  /**
+   * Open "Find in Page" popup
+   */
+  openFindInPage() {
+    this.controller.openFindInPage();
+  }
+
+  /**
+   * Set or update value in storage
+   *
+   * @param {*} key
+   * @param {*} value
+   */
+  set(key, value) {
+    window.localStorage.setItem(
+      `ferdi-user-${key}`, JSON.stringify(value),
+    );
+  }
+
+  /**
+   * Get value from storage
+   *
+   * @param {*} key
+   * @return Value of the key
+   */
+  get(key) {
+    return JSON.parse(window.localStorage.getItem(
+      `ferdi-user-${key}`,
+    ));
+  }
+
+  /**
+   * Open a URL in an external browser
+   *
+   * @param {*} url
+   */
+  externalOpen(url) {
+    ipcRenderer.sendToHost('new-window', url);
+  }
+}

--- a/src/webview/lib/Userscript.js
+++ b/src/webview/lib/Userscript.js
@@ -120,4 +120,13 @@ export default class Userscript {
   externalOpen(url) {
     ipcRenderer.sendToHost('new-window', url);
   }
+
+  /**
+   * Open a URL in the current service
+   * 
+   * @param {*} url 
+   */
+  internalOpen(url) {
+    window.location.href = url;
+  }
 }


### PR DESCRIPTION
Until now, user scripts (`user.js`) only have very limited ways to interact with any of Ferdi's features. This PR aims to improve this interaction.

This PR will:
- Add a minimal template when creating the `user.js` to help kickstart the user script:
```
module.exports = (config, Ferdi) => {
  // Write your scripts here
  console.log("Hello, World!", config);
}
```
- Add a new "Userscript" class that helps user scripts in using Ferdi's features:

A new instance of the `Userscript` class is given to userscripts using the second "Ferdi" argument (see template above). The `Ferdi` instance gives the script the following methods and variables:

`config` - Service configuration, same as the first "config" argument
`settings` - Full settings object, containing Ferdi's and the service's settings, e.g.:
```
{
   "overrideSpellcheckerLanguage":false,
   "app":{
      "autoLaunchInBackground":false,
      "runInBackground":true,
      "reloadAfterResume":true,
      "enableSystemTray":false,
      "startMinimized":true,
      "minimizeToSystemTray":false,
      "privateNotifications":false,
      "showDisabledServices":true,
      "showMessageBadgeWhenMuted":true,
      "showDragArea":true,
      "enableSpellchecking":true,
      "spellcheckerLanguage":"en-us",
      "darkMode":false,
      "locale":"en-US",
      "fallbackLocale":"en-US",
      "beta":false,
      "isAppMuted":false,
      "enableGPUAcceleration":true,
      "serviceLimit":5,
      "server":"https://api.getferdi.com",
      "predefinedTodoServer":"https://app.franztodos.com",
      "autohideMenuBar":false,
      "lockingFeatureEnabled":false,
      "locked":false,
      "lockedPassword":"",
      "useTouchIdToUnlock":true,
      "scheduledDNDEnabled":false,
      "scheduledDNDStart":"17:00",
      "scheduledDNDEnd":"09:00",
      "hibernate":true,
      "hibernationStrategy":"10",
      "inactivityLock":0,
      "automaticUpdates":true,
      "showServiceNavigationBar":false,
      "universalDarkMode":true,
      "adaptableDarkMode":false,
      "accentColor":"#7367f0",
      "serviceRibbonWidth":68,
      "iconSize":20,
      "sentry":false,
      "navigationBarBehaviour":"never",
      "customTodoServer":"",
      "noUpdates":false,
      "todoServer":"isUsingCustomTodoService",
      "isDarkThemeActive":false
   },
   "service":{
      "franzVersion":"5.4.4-beta.3",
      "id":"abdefghijklmop",
      "spellcheckerLanguage":null,
      "isDarkModeEnabled":false,
      "team":"",
      "url":"https://web.telegram.org",
      "hasCustomIcon":false,
      "recipe":{
         "id":"telegram",
         "name":"Telegram",
         "description":"Telegram",
         "version":"1.0.5",
         "path":"C:/.../Ferdi/recipes/telegram",
         "serviceURL":"https://web.telegram.org",
         "hasDirectMessages":true,
         "hasIndirectMessages":false,
         "hasNotificationSound":true,
         "hasTeamId":false,
         "hasPredefinedUrl":false,
         "hasCustomUrl":false,
         "hasHostedOption":false,
         "urlInputPrefix":"",
         "urlInputSuffix":"",
         "message":"",
         "disablewebsecurity":false,
         "rawAuthor":"Stefan Malzner <stefan@adlk.io>"
      }
   }
}
```

`onSettingsUpdate(handler)` - Set a custom callback that should be called when the settings object above has changed

`setBadge(direct = 0, indirect = 0)` - Set badge count (unread messages count) for the current service

`injectCSSFiles(...files)` - Inject local CSS file or files into the page

`injectCSS(styles)` - Inject CSS string into the page

`openFindInPage()` - Open the "Find in Page" popup

`set(key, value)` and `get(key)` - Simple key-value store that can be used inside user scripts to save state.

`externalOpen(url)` - Open a URL in an external browser, as supposed to `location.href = ...` which opens the URL inside Ferdi 