### PR TITLE
Make update banner dismissable

### DIFF
--- a/src/components/AppUpdateInfoBar.js
+++ b/src/components/AppUpdateInfoBar.js
@@ -24,6 +24,7 @@ class AppUpdateInfoBar extends Component {
   static propTypes = {
     onInstallUpdate: PropTypes.func.isRequired,
     nextAppReleaseVersion: PropTypes.string,
+    onHide: PropTypes.func.isRequired,
   };
 
   static defaultProps = {
@@ -39,6 +40,7 @@ class AppUpdateInfoBar extends Component {
     const {
       onInstallUpdate,
       nextAppReleaseVersion,
+      onHide,
     } = this.props;
 
     return (
@@ -46,7 +48,7 @@ class AppUpdateInfoBar extends Component {
         type="primary"
         ctaLabel={intl.formatMessage(messages.buttonInstallUpdate)}
         onClick={onInstallUpdate}
-        sticky
+        onHide={onHide}
       >
         <span className="mdi mdi-information" />
         {intl.formatMessage(messages.updateAvailable)}

--- a/src/components/auth/AuthLayout.js
+++ b/src/components/auth/AuthLayout.js
@@ -27,6 +27,10 @@ export default @observer class AuthLayout extends Component {
     appUpdateIsDownloaded: PropTypes.bool.isRequired,
   };
 
+  state = {
+    shouldShowAppUpdateInfoBar: true,
+  }
+
   static defaultProps = {
     nextAppReleaseVersion: null,
   };
@@ -62,10 +66,13 @@ export default @observer class AuthLayout extends Component {
               {intl.formatMessage(globalMessages.notConnectedToTheInternet)}
             </InfoBar>
           )}
-          {appUpdateIsDownloaded && (
+          {appUpdateIsDownloaded && this.state.shouldShowAppUpdateInfoBar && (
             <AppUpdateInfoBar
               nextAppReleaseVersion={nextAppReleaseVersion}
               onInstallUpdate={installAppUpdate}
+              onHide={() => {
+                this.setState({ shouldShowAppUpdateInfoBar: false });
+              }}
             />
           )}
           {isOnline && !isAPIHealthy && (

--- a/src/components/layout/AppLayout.js
+++ b/src/components/layout/AppLayout.js
@@ -81,6 +81,10 @@ class AppLayout extends Component {
     hasActivatedTrial: PropTypes.bool.isRequired,
   };
 
+  state = {
+    shouldShowAppUpdateInfoBar: true,
+  }
+
   static defaultProps = {
     children: [],
     nextAppReleaseVersion: null,
@@ -181,10 +185,13 @@ class AppLayout extends Component {
                   {intl.formatMessage(messages.servicesUpdated)}
                 </InfoBar>
               )}
-              {appUpdateIsDownloaded && (
+              { appUpdateIsDownloaded && this.state.shouldShowAppUpdateInfoBar && (
                 <AppUpdateInfoBar
                   nextAppReleaseVersion={nextAppReleaseVersion}
                   onInstallUpdate={installAppUpdate}
+                  onHide={() => {
+                    this.setState({ shouldShowAppUpdateInfoBar: false });
+                  }}
                 />
               )}
               <BasicAuth />


### PR DESCRIPTION
Co-Authored-By: Mahadevan Sreenivasan <mahadevan_sv@yahoo.com>

### Description
- Remove the sticky option passed to InfoBar in AppUpdateInfoBar
- Use component state to manage visibility of AppUpdateInfoBar in AuthLayout and AppLayout.
- InfoBar will be dismissed only for the current session

### Motivation and Context
Addresses feature request #561 

### How Has This Been Tested?
Tested in Windows 10 development environment
Tested by temporarily disabling `appUpdateIsDownloaded` in AppLayout.js and AuthLayout.js

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
- [ x ] My code follows the code style of this project (run `$ yarn lint`).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
