### PR TITLE
fix: Home button doesn't navigate to Service URL

### DIFF
--- a/src/features/webControls/containers/WebControlsScreen.js
+++ b/src/features/webControls/containers/WebControlsScreen.js
@@ -52,11 +52,8 @@ class WebControlsScreen extends Component {
   }
 
   goHome() {
-    const { reloadActive } = this.props.actions.service;
-
     if (!this.webview) return;
-
-    reloadActive();
+    this.webview.goToIndex(0);
   }
 
   reload() {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -602,8 +602,7 @@ export default class ServicesStore extends Store {
     service.resetMessageCount();
 
     // service.webview.loadURL(service.url);
-    //service.webview.reload();
-    service.webview.goToIndex(0);
+    service.webview.reload();
   }
 
   @action _reloadActive() {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -602,7 +602,8 @@ export default class ServicesStore extends Store {
     service.resetMessageCount();
 
     // service.webview.loadURL(service.url);
-    service.webview.reload();
+    //service.webview.reload();
+    service.webview.goToIndex(0);
   }
 
   @action _reloadActive() {


### PR DESCRIPTION
Home button is not working as expected (#571).  Home button in service navigation bar doesn't navigate to Service Base URL.


### Description

  -  Currently this doesnt happen because the reload() method in ServiceStore simply reloads the chromium webview.
  - Change .reload() to .goToIndex(0) where 0 is the absolute index in navigation history - Documentation can be found here -[link]( https://www.electronjs.org/docs/api/webview-tag#webviewgotoindexindex)

### Motivation and Context

This change is to address #571 

### How Has This Been Tested?
This was tested on Windows 10 on a dev build of Ferdi. 

 - Navigated several levels down deep inside Github and clicked on the home button to make sure that the base URL was loaded by the webview
 - Right clicked on service and clicked Reload Service to make sure that .goToIndex(0) still works.
### Screenshots (if appropriate):
![ferdi_571_fix](https://user-images.githubusercontent.com/1255523/79312383-71022800-7f1c-11ea-9502-4a8f83e2176e.gif)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
