### PR TITLE
Refocus Webview only for active service

### DIFF
--- a/src/components/services/content/ServiceWebview.js
+++ b/src/components/services/content/ServiceWebview.js
@@ -41,9 +41,14 @@ class ServiceWebview extends Component {
 
   refocusWebview = () => {
     const { webview } = this;
+    debug("Refocus Webview is called", this.props.service);
     if (!webview) return;
-    webview.view.blur();
-    webview.view.focus();
+    if (this.props.service.isActive) {
+      webview.view.blur();
+      webview.view.focus();
+    } else {
+      debug("Refocus not required - Not active service");
+    }
   };
 
   render() {

--- a/src/components/services/content/ServiceWebview.js
+++ b/src/components/services/content/ServiceWebview.js
@@ -41,13 +41,13 @@ class ServiceWebview extends Component {
 
   refocusWebview = () => {
     const { webview } = this;
-    debug("Refocus Webview is called", this.props.service);
+    debug('Refocus Webview is called', this.props.service);
     if (!webview) return;
     if (this.props.service.isActive) {
       webview.view.blur();
       webview.view.focus();
     } else {
-      debug("Refocus not required - Not active service");
+      debug('Refocus not required - Not active service');
     }
   };
 

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -495,9 +495,7 @@ export default class ServicesStore extends Store {
     const service = this.one(serviceId);
 
     if (service.webview) {
-      if (document.activeElement) {
-        document.activeElement.blur();
-      }
+      service.webview.blur();
       service.webview.focus();
     }
   }


### PR DESCRIPTION
Co-Authored-By: Sampath Kumar Krishnan <sampathblam@users.noreply.github.com>

Addresses #343 to keep the current service in focus so that users don't lose focus while typing.

### Description
  - add check to identify if the webview belongs to the active service during refocussing a webview.
  - blur and focus the webview only for the active service.
  - replace document.activeelement.blur() with activeservice.webview.blur() in ServiceStore. This is done to make sure the active service gets focus in case electron loses focus of the browser window. 
See - https://github.com/electron/electron/issues/7329

### Motivation and Context
Addresses #343 

### How Has This Been Tested?
This has been tested on a dev environment of Ferdi on Windows 10 (develop). Need extensive testing on other platforms especially by the users who reported them.

### Screenshots (if appropriate):

###Before

Slack losing focus when whatsapp is reloaded

![ferdi_343_fix_1](https://user-images.githubusercontent.com/1255523/79774436-6e566700-8350-11ea-8cad-6661a4883d1d.gif)

###After
Slack doesnt lose focus when whatsapp is reloaded.

![ferdi_343_fix_2](https://user-images.githubusercontent.com/1255523/79779000-3e5e9200-8357-11ea-9732-4f3137cbcfa4.gif)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
