### PR TITLE
Enhance Travis CI/AppVeyor configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,24 +14,21 @@ matrix:
       osx_image: xcode11
 
 language: node_js
-# Handle git submodules yourself
 git:
   submodules: false
-# Use sed to replace the SSH URL with the public URL, then initialize submodules
+branches:
+  only:
+    - develop
+    - release
+cache: npm
+
 before_install:
   - git submodule update --init --recursive
 install:
-  - echo do nothing
-before_script:
   - travis_retry npx lerna bootstrap
   - travis_retry npm install node-sass -g
+before_script:
+  - npm run lint && npm run test
 script:
-  - travis_retry travis_wait 100 npm run build
+  - echo $TRAVIS_BRANCH
 
-cache: npm
-
-branches:
-  except:
-    - i18n
-    - l10n_master
-    - l10n_develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 matrix:
+  fast_finish: true
   include:
     - os: linux
       dist: xenial
@@ -11,6 +12,7 @@ matrix:
             - libxkbfile-dev
             - rpm
     - os: osx
+      if: branch = release
       osx_image: xcode11
 
 language: node_js
@@ -30,5 +32,8 @@ install:
 before_script:
   - npm run lint && npm run test
 script:
-  - echo $TRAVIS_BRANCH
+  - |
+    if [ $TRAVIS_BRANCH == "release" ]; then
+      travis_retry travis_wait 100 npm run build
+    fi
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,20 @@
-environment:
-  APPVEYOR_CACHE_SKIP_RESTORE: true
+version: build-{build}
 
-version: 5.4.1-beta.4.{build}
+skip_tags: true
+skip_branch_with_pr: true
+
+cache:
+  - '%APPDATA%\npm-cache'
+  - node_modules
 
 install:
   - appveyor-retry git submodule update --init --recursive
   - ps: Install-Product node 10
   - appveyor-retry npx lerna bootstrap
 
-cache:
-  - '%APPDATA%\npm-cache'
-
 before_build:
-  - npm run lint
+  - npm run lint && npm test
   - cmd: set NODE_ENV=production
 
 build_script:
   - appveyor-retry npm run build
-
-branches:
-  except:
-    - i18n
-    - l10n_master
-    - l10n_develop
-
-skip_commits:
-  files:
-    - src/i18n/locales/*.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: build-{build}
-
+branches:
+  only:
+    - release
 skip_tags: true
 skip_branch_with_pr: true
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,8 @@
 module.exports = {
   roots: ['src'],
+  testPathIgnorePatterns: [
+    'node_modules/',
+    'recipes/',
+    'src/internal-server',
+  ]
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint": "eslint --quiet --fix src",
     "manage-translations": "node ./src/i18n/manage-translations.js",
     "prebuild": "gulp build",
-    "build": "npx electron-builder --publish onTag",
+    "build": "npx electron-builder",
     "rebuild": "npx electron-rebuild",
     "commit": "git-cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",


### PR DESCRIPTION
For #629 and #635.

### Description
This optimize the CI configuration as to not build the binaries everytime. I think we need to build the binaries on develop and tags (for releases) only. We could run the utility scripts/tests only in the other cases. Also need to fix Windows signing.

### Motivation and Context
The build queues are sometimes getting clogged when a lot of contributions are happening at the same time. Building the binaries produces builds sometimes lasting more than 1 hour.

### Screenshots (before):

<img width="1062" alt="Screen Shot 2020-04-24 at 6 02 34 PM" src="https://user-images.githubusercontent.com/412895/80243157-30aa5480-8656-11ea-9e8b-a00f3abe3827.png">

<img width="1021" alt="Screen Shot 2020-04-24 at 6 01 59 PM" src="https://user-images.githubusercontent.com/412895/80243152-2daf6400-8656-11ea-9410-d16a730e6999.png">

### Notes:

- [x] Fix Windows signing / prevent unnecessary build/signing attempts
- [ ] Rename l18n_develop branch to i18n /cc @vantezzen 
- [ ] Ignore @all-contributors pull requests