### PR TITLE
Review launch on startup for macOS, start Ferdi app, not renderer

### DIFF
--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -33,8 +33,11 @@ const {
 const mainWindow = remote.getCurrentWindow();
 
 const defaultLocale = DEFAULT_APP_SETTINGS.locale;
+
+const executablePath = isMac ? remote.process.execPath : process.execPath;
 const autoLauncher = new AutoLaunch({
   name: 'Ferdi',
+  path: executablePath,
 });
 
 const CATALINA_NOTIFICATION_HACK_KEY = '_temp_askedForCatalinaNotificationPermissions';
@@ -324,8 +327,10 @@ export default class AppStore extends Store {
 
     try {
       if (enable) {
+        debug('enabling launch on startup', executablePath);
         autoLauncher.enable();
       } else {
+        debug('disabling launch on startup');
         autoLauncher.disable();
       }
     } catch (err) {


### PR DESCRIPTION
# Description
On Mac OS X, the renderer process has a different `process.execPath` from the main process. This leads to the renderer being added to the Login Items for launching at startup. Instead, we should be adding the `execPath` from the main process, which corresponds to the packaged Ferdi application.

This is necessary after the change in Electron: https://github.com/electron/electron/pull/13839

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes launching at startup for Mac users.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually verified that Ferdi is added to Login Items instead of the renderer process.

### Screenshots (if appropriate):
![beforeafter](https://user-images.githubusercontent.com/1170755/80802878-88205700-8b65-11ea-92ae-4d171dfba841.png)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ yarn lint`).
<!---- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. -->