### PR TITLE
Restore window last closed maximize/fullscreen state

### DIFF
--- a/src/features/todos/components/TodosWebview.js
+++ b/src/features/todos/components/TodosWebview.js
@@ -134,7 +134,7 @@ class TodosWebview extends Component {
     const webViewInstance = this;
     this.webview.addEventListener('dom-ready', () => {
       webViewInstance.webview.setUserAgent(userAgent(true));
-    })
+    });
   }
 
   startResize = (event) => {

--- a/src/index.js
+++ b/src/index.js
@@ -152,8 +152,8 @@ const createWindow = () => {
   const mainWindowState = windowStateKeeper({
     defaultWidth: DEFAULT_WINDOW_OPTIONS.width,
     defaultHeight: DEFAULT_WINDOW_OPTIONS.height,
-    maximize: false,
-    fullScreen: false,
+    maximize: true, // Automatically maximizes the window, if it was last clsoed maximized
+    fullScreen: true, // Automatically restores the window to full screen, if it was last closed full screen
   });
 
   let posX = mainWindowState.x || DEFAULT_WINDOW_OPTIONS.x;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The API for electron-window-state is a little confusing in the creation of the state manager since the parameter name implies that it will set the window to maximize/fullscreen. Instead, it toggles the restore behavior: https://github.com/mawie81/electron-window-state#api

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This should address the issue in #314.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manually tested.

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project (run `$ npm run lint`).
<!---- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. -->
