### PR TITLE
Make the notifications badge work with LauncherAPI-compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ferdi",
   "productName": "Ferdi",
+  "desktopName": "ferdi.desktop",
   "appId": "com.kytwb.ferdi",
   "version": "5.5.0",
   "description": "Messaging app for WhatsApp, Slack, Telegram, HipChat, Hangouts and many many more.",


### PR DESCRIPTION
docks

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
This commit sets the desktopName option in package.json to the .desktop filename used to launch the application. This is needed for the unread messages counter badge to work with LauncherAPI-based docks on Linux.

### Motivation and Context
The Ferdi icon doesn't show the counter badge on elementaryOS, after some googling I found out it was because of this missing option.

### Screenshots
![image](https://user-images.githubusercontent.com/749488/81599271-ca843800-939e-11ea-9e66-868f512f4e95.png)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally