### PR TITLE
Use Tray popUpContextMenu on macOS/Windows only

### DIFF
--- a/src/lib/Tray.js
+++ b/src/lib/Tray.js
@@ -55,6 +55,9 @@ export default class TrayIcon {
       const { isAppMuted } = appSettings.data;
       this.trayMenuTemplate[1].label = isAppMuted ? 'Enable Notifications && Audio' : 'Disable Notifications && Audio';
       this.trayMenu = Menu.buildFromTemplate(this.trayMenuTemplate);
+      if (isLinux) {
+        this.trayIcon.setContextMenu(this.trayMenu);
+      }
     }
   }
 

--- a/src/lib/Tray.js
+++ b/src/lib/Tray.js
@@ -2,6 +2,11 @@ import {
   app, Menu, nativeImage, nativeTheme, systemPreferences, Tray, ipcMain,
 } from 'electron';
 import path from 'path';
+import {
+  isMac,
+  isWindows,
+  isLinux,
+} from '../environment';
 
 const FILE_EXTENSION = process.platform === 'win32' ? 'ico' : 'png';
 const INDICATOR_TRAY_PLAIN = 'tray';
@@ -61,6 +66,9 @@ export default class TrayIcon {
     this.trayIcon.setToolTip('Ferdi');
 
     this.trayMenu = Menu.buildFromTemplate(this.trayMenuTemplate);
+    if (isLinux) {
+      this.trayIcon.setContextMenu(this.trayMenu);
+    }
 
     ipcMain.on('initialAppSettings', (event, appSettings) => {
       this._updateTrayMenu(appSettings);
@@ -81,9 +89,11 @@ export default class TrayIcon {
       }
     });
 
-    this.trayIcon.on('right-click', () => {
-      this.trayIcon.popUpContextMenu(this.trayMenu);
-    });
+    if (isMac || isWindows) {
+      this.trayIcon.on('right-click', () => {
+        this.trayIcon.popUpContextMenu(this.trayMenu);
+      });
+    }
 
     if (process.platform === 'darwin') {
       this.themeChangeSubscriberId = systemPreferences.subscribeNotification('AppleInterfaceThemeChangedNotification', () => {


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->
I noticed [popUpContextMenu](https://www.electronjs.org/docs/api/tray#traypopupcontextmenumenu-position-macos-windows) and the [right-click event](https://www.electronjs.org/docs/api/tray#event-right-click-macos-windows) are only available on macOS/Windows, so I refactored the code to use `popUpContextMenu` on macOS/Windows and `setContextMenu` on Linux. It still has the expected behavior on macOS but I haven't been able to test on Linux.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I ran into https://github.com/getferdi/ferdi/issues/484 while doing some triage and reviewed it. Reviewing the pull request @vantezzen hinted at made me double check the documentation.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally