### PR TITLE
Make Tray icons more robust on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4403,6 +4403,11 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@nornagon/put": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@nornagon/put/-/put-0.0.8.tgz",
+      "integrity": "sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow=="
+    },
     "@octokit/endpoint": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.1.tgz",
@@ -5139,6 +5144,16 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "abstract-socket": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/abstract-socket/-/abstract-socket-2.1.1.tgz",
+      "integrity": "sha512-YZJizsvS1aBua5Gd01woe4zuyYBGgSMeqDOB6/ChwdTI904KP6QGtJswXl4hcqWxbz86hQBe++HWV0hF1aGUtA==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.2.1",
+        "nan": "^2.12.1"
+      }
     },
     "accepts": {
       "version": "1.0.7",
@@ -9134,6 +9149,21 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
+    "dbus-next": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/dbus-next/-/dbus-next-0.8.2.tgz",
+      "integrity": "sha512-E2wkbhZzzsgmY+jxIdeuhA1nVT697I5koRIRJTk3doTeukwtzqSFG89RC5XK8OsLG/eHDZ8PVNptUuEPkhdPbA==",
+      "requires": {
+        "@nornagon/put": "0.0.8",
+        "abstract-socket": "^2.0.0",
+        "event-stream": "3.3.4",
+        "hexy": "^0.2.10",
+        "jsbi": "^2.0.5",
+        "long": "^4.0.0",
+        "safe-buffer": "^5.1.1",
+        "xml2js": "^0.4.17"
+      }
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -11452,6 +11482,30 @@
       "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.3.tgz",
       "integrity": "sha512-b7Qi1JNzY4BfAYfnIRanLk0DOD1gdkWHT4GISIn8Q2tAf3LpU8SP2CMwWaq40imYoKWbtN4ZhbSRxvsnikooZQ=="
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      },
+      "dependencies": {
+        "split": {
+          "version": "0.3.3",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+          "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+          "requires": {
+            "through": "2"
+          }
+        }
+      }
+    },
     "eventemitter2": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
@@ -12425,6 +12479,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.2.tgz",
       "integrity": "sha1-lzHc9WeMf660T7kDxPct9VGH+nc=",
       "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "from2": {
       "version": "2.3.0",
@@ -15628,6 +15687,11 @@
       "resolved": "https://registry.npmjs.org/hex-to-rgba/-/hex-to-rgba-1.0.2.tgz",
       "integrity": "sha512-fL+4NFccs86iOuDnFl1Mhyn471qTPAkpE7k39+JYGPMB3+S9LoUnauQI2nz6BUb3DpYQCx8RqENbaf8IFdKYOg=="
     },
+    "hexy": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.2.11.tgz",
+      "integrity": "sha512-ciq6hFsSG/Bpt2DmrZJtv+56zpPdnq+NQ4ijEFrveKN0ZG1mhl/LdT1NQZ9se6ty1fACcI4d4vYqC9v8EYpH2A=="
+    },
     "history": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/history/-/history-3.3.0.tgz",
@@ -17490,6 +17554,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-2.0.5.tgz",
+      "integrity": "sha512-TzO/62Hxeb26QMb4IGlI/5X+QLr9Uqp1FPkwp2+KOICW+Q+vSuFj61c8pkT6wAns4WcK56X7CmSHhJeDGWOqxQ=="
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -18507,6 +18576,11 @@
       "integrity": "sha512-Sgr5lbboAUBo3eXCSPL4/KoVz3ROKquOjcctxmHIt+vol2DrqTQe3SwkKKuYhEiWB5kYa13YyopJ69deJ1irzQ==",
       "dev": true
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -18825,6 +18899,11 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
       "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
     },
     "map-visit": {
       "version": "1.0.0",
@@ -21350,6 +21429,14 @@
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
       }
     },
     "pbkdf2": {
@@ -24975,6 +25062,14 @@
         }
       }
     },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "~0.1.1"
+      }
+    },
     "stream-each": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -27872,6 +27967,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmlhttprequest": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "cld3-asm": "1.0.1",
     "css": "2.2.4",
     "darkreader": "4.7.15",
+    "dbus-next": "0.8.2",
     "du": "^0.1.0",
     "electron-dl": "1.14.0",
     "electron-fetch": "1.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ import {
 import { mainIpcHandler as basicAuthHandler } from './features/basicAuth';
 import ipcApi from './electron/ipc-api';
 import Tray from './lib/Tray';
+import DBus from './lib/DBus';
 import Settings from './electron/Settings';
 import handleDeepLink from './electron/deepLinking';
 import { isPositionValid } from './electron/windowUtils';
@@ -213,6 +214,9 @@ const createWindow = () => {
   // Initialize System Tray
   const trayIcon = new Tray();
 
+  // Initialize DBus interface
+  const dbus = new DBus(trayIcon);
+
   // Initialize ipcApi
   ipcApi({
     mainWindow,
@@ -222,6 +226,9 @@ const createWindow = () => {
     },
     trayIcon,
   });
+
+  // Connect to the DBus after ipcApi took care of the System Tray
+  dbus.start();
 
   // Manage Window State
   mainWindowState.manage(mainWindow);
@@ -265,6 +272,7 @@ const createWindow = () => {
         mainWindow.hide();
       }
     } else {
+      dbus.stop();
       app.quit();
     }
   });

--- a/src/lib/DBus.js
+++ b/src/lib/DBus.js
@@ -1,0 +1,49 @@
+import {
+  sessionBus,
+} from 'dbus-next';
+import {
+  isLinux,
+} from '../environment';
+
+export default class DBus {
+  bus = null;
+
+  constructor(trayIcon) {
+    this.trayIcon = trayIcon;
+  }
+
+  start() {
+    if (!isLinux || this.bus) return;
+
+    try {
+      this.bus = sessionBus();
+    } catch {
+      // Error connecting to the bus.
+      return;
+    }
+
+    // HACK Hook onto the MessageBus to track StatusNotifierWatchers
+    this.bus._addMatch("type='signal',sender='org.freedesktop.DBus',interface='org.freedesktop.DBus',path='/org/freedesktop/DBus',member='NameOwnerChanged'");
+    const mangled = JSON.stringify({
+      path: '/org/freedesktop/DBus',
+      interface: 'org.freedesktop.DBus',
+      member: 'NameOwnerChanged',
+    });
+    this.bus._signals.on(mangled, (msg) => {
+      const [name, oldOwner, newOwner] = msg.body;
+      if (name === 'org.kde.StatusNotifierWatcher' && oldOwner !== newOwner && newOwner !== '') {
+        // Leave ample time for the StatusNotifierWatcher to be initialized
+        setTimeout(() => {
+          this.trayIcon.recreateIfVisible();
+        }, 400);
+      }
+    });
+  }
+
+  stop() {
+    if (!this.bus) return;
+
+    this.bus.disconnect();
+    this.bus = null;
+  }
+}

--- a/src/lib/Tray.js
+++ b/src/lib/Tray.js
@@ -51,6 +51,8 @@ export default class TrayIcon {
   ];
 
   _updateTrayMenu(appSettings) {
+    if (!this.trayIcon) return;
+
     if (appSettings.type === 'app') {
       const { isAppMuted } = appSettings.data;
       this.trayMenuTemplate[1].label = isAppMuted ? 'Enable Notifications && Audio' : 'Disable Notifications && Audio';

--- a/src/lib/Tray.js
+++ b/src/lib/Tray.js
@@ -22,6 +22,8 @@ export default class TrayIcon {
 
   trayMenu = null;
 
+  visible = false;
+
   trayMenuTemplate = [
     {
       label: 'Show Ferdi',
@@ -50,6 +52,16 @@ export default class TrayIcon {
     },
   ];
 
+  constructor() {
+    ipcMain.on('initialAppSettings', (event, appSettings) => {
+      this._updateTrayMenu(appSettings);
+    });
+
+    ipcMain.on('updateAppSettings', (event, appSettings) => {
+      this._updateTrayMenu(appSettings);
+    });
+  }
+
   _updateTrayMenu(appSettings) {
     if (!this.trayIcon) return;
 
@@ -64,6 +76,11 @@ export default class TrayIcon {
   }
 
   show() {
+    this.visible = true;
+    this._show();
+  }
+
+  _show() {
     if (this.trayIcon) return;
 
     this.trayIcon = new Tray(this._getAsset('tray', INDICATOR_TRAY_PLAIN));
@@ -74,14 +91,6 @@ export default class TrayIcon {
     if (isLinux) {
       this.trayIcon.setContextMenu(this.trayMenu);
     }
-
-    ipcMain.on('initialAppSettings', (event, appSettings) => {
-      this._updateTrayMenu(appSettings);
-    });
-
-    ipcMain.on('updateAppSettings', (event, appSettings) => {
-      this._updateTrayMenu(appSettings);
-    });
 
     this.trayIcon.on('click', () => {
       if (app.mainWindow.isMinimized()) {
@@ -108,6 +117,11 @@ export default class TrayIcon {
   }
 
   hide() {
+    this.visible = false;
+    this._hide();
+  }
+
+  _hide() {
     if (!this.trayIcon) return;
 
     this.trayIcon.destroy();
@@ -116,6 +130,17 @@ export default class TrayIcon {
     if (process.platform === 'darwin' && this.themeChangeSubscriberId) {
       systemPreferences.unsubscribeNotification(this.themeChangeSubscriberId);
       this.themeChangeSubscriberId = null;
+    }
+  }
+
+  recreateIfVisible() {
+    if (this.visible) {
+      this._hide();
+      setTimeout(() => {
+        if (this.visible) {
+          this._show();
+        }
+      }, 100);
     }
   }
 


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
This patch aims to make Tray icons less likely to disappear under Linux.

First, it fixes a bug where the `setContextMenu` method may have been called on `null`, generating an error message.

Second, it watches the session DBus, where Ferdi is communicating with `org.kde.StatusNotifierWatcher` to display the tray icons. If the watcher is restarted for some reason, for example, the screen is locked in GNOME Shell (which disables all Shell extensions, including the TopIcons, which implements StatusNotifierWatcher to display the icons) or a standalone tray application (like Waybar under Wayland) is restarted, Ferdi's Tray icon gets destroyed and recreated. This seems to prevent it from disappearing.

Unfortunately, there is a small time window where the StatusNotifierWatcher may own its name on the bus, but is not actually ready to receive new Tray icons. There doesn't appear to be a way to detect this from the DBus, so instead there is a hardcoded timeout (currently 400 milliseconds, which seems sufficiently long).

This patch adds [dbus-next](https://github.com/dbusjs/node-dbus-next) as a dependency to `packages.json`. While this is pure Javascript library, so it doesn't need any compiled dependencies, and is only invoked on Linux, build or runtime error might have been introduces. Because I don't have access to a Mac OS or Window machine, I couldn't test for these. Therefore I would like to ask someone to try these platforms, too, before merging.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The main motivation is to keep the Tray icon from disappearing (e.g., #437, #555, #697), and the error regarding `null` from being generated (https://github.com/getferdi/ferdi/issues/437#issuecomment-628497664). The main idea comes from https://github.com/zulip/zulip-desktop/issues/910#issuecomment-608056150, but I use a pure Javascript DBus client instead of relying on an external helper program. In addition, DBus client capabilities are added to Ferdi, which might be also useful later.

Note that Qt and GTK applications are able to preserve their tray icons even without timeouts and listening for the StatusNotifierWatcher. So the API provided by Electron, Tray, is somewhat limited compared to them in this regard. We could maybe implement our own Tray icons over DBus, instead of relying on the built-in Electron API, to achieve even more robustness.

In the future, Ferdi could also expose additional information over DBus, for example, the number of unread notifications. Having such interfaces may allow users to write their own scripts and applets to interact with, instead of being limited to a single tray icon (e.g., https://github.com/getferdi/ferdi/issues/720#issuecomment-626350668).

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally (but only on Linux)