### PR TITLE
Load disable hibernation per service status on startup

### DIFF
--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -77,7 +77,7 @@ export default class Service {
 
   @observable restrictionType = null;
 
-  @observable isHibernationEnabled = false;
+  @observable disableHibernation = false;
 
   @observable lastUsed = Date.now(); // timestamp
 
@@ -136,7 +136,7 @@ export default class Service {
 
     this.spellcheckerLanguage = data.spellcheckerLanguage !== undefined ? data.spellcheckerLanguage : this.spellcheckerLanguage;
 
-    this.isHibernationEnabled = data.isHibernationEnabled !== undefined ? data.isHibernationEnabled : this.isHibernationEnabled;
+    this.disableHibernation = data.disableHibernation !== undefined ? data.disableHibernation : this.disableHibernation;
 
     this.recipe = recipe;
 


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
Disable hibernation per service settings were not being loaded properly, because in `ServiceModel`, the property was named `isHibernationEnabled` instead of `disableHibernation` (https://github.com/getferdi/ferdi/issues/715#issuecomment-627009491). I changed the property name to `disableHibernation` from `isHibernationEnabled`, as this change had a much lower impact than using `isHibernationEnabled` instead of `disableHibernation` in every other place (the model had no associated logic to be changed from positive to negative).

### Motivation and Context
This should hopefully fix #715. As `disableHibernation` was already being saved correctly to the Ferdi server (https://github.com/getferdi/ferdi/issues/715#issuecomment-625300320), the setting should now persist both for server and local settings storage. If you set some services not to hibernate previously (but the setting wasn't loaded correctly), that should now be loaded (so you don't have to disable hibernation for the service again).


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally