### PR TITLE
Fix setting of webview disablewebsecurity attribute

### DIFF
--- a/src/components/services/content/ServiceWebview.js
+++ b/src/components/services/content/ServiceWebview.js
@@ -79,7 +79,7 @@ class ServiceWebview extends Component {
         }}
         onUpdateTargetUrl={this.updateTargetUrl}
         useragent={service.userAgent}
-        disablewebsecurity={service.recipe.disablewebsecurity}
+        disablewebsecurity={service.recipe.disablewebsecurity ? true : undefined}
         allowpopups
       />
     );


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->
Set `disablewebsecurity` to `undefined` for service webviews. Otherwise, it will be set to `disablewebsecurity="off"`, which existence is interpreted by electron as "Disable web security".

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes a security hole, which shows up in debug mode:

```
Ferdi:Services Service logged a message: +1ms %cElectron Security Warning (Disabled webSecurity) font-weight: bold; This renderer process has "webSecurity" disabled. This exposes users of this app to severe security risks.

For more information and help, consult https://electronjs.org/docs/tutorial/security.
This warning will not show up once the app is packaged.
```

### Screenshots
<!-- Remove the section if this does not apply. -->
<img width="1236" alt="Screen Shot 2020-05-16 at 8 39 25 PM" src="https://user-images.githubusercontent.com/1170755/82779293-ac8bee00-9e08-11ea-877b-635ce0b90c20.png">


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally