### PR TITLE
Patch getDisplayMedia for screen sharing in all services

### DIFF
--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/first */
-import { ipcRenderer, remote } from 'electron';
+import { ipcRenderer, remote, desktopCapturer } from 'electron';
 import path from 'path';
 import { autorun, computed, observable } from 'mobx';
 import fs from 'fs-extra';
@@ -31,6 +31,69 @@ import { DEFAULT_APP_SETTINGS } from '../config';
 import { isDevMode } from '../environment';
 
 const debug = require('debug')('Ferdi:Plugin');
+
+const screenShareCss = `
+.desktop-capturer-selection {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100vh;
+  background: rgba(30,30,30,.75);
+  color: #fff;
+  z-index: 10000000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.desktop-capturer-selection__scroller {
+  width: 100%;
+  max-height: 100vh;
+  overflow-y: auto;
+}
+.desktop-capturer-selection__list {
+  max-width: calc(100% - 100px);
+  margin: 50px;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  list-style: none;
+  overflow: hidden;
+  justify-content: center;
+}
+.desktop-capturer-selection__item {
+  display: flex;
+  margin: 4px;
+}
+.desktop-capturer-selection__btn {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 145px;
+  margin: 0;
+  border: 0;
+  border-radius: 3px;
+  padding: 4px;
+  background: #252626;
+  text-align: left;
+  transition: background-color .15s, box-shadow .15s;
+}
+.desktop-capturer-selection__btn:hover,
+.desktop-capturer-selection__btn:focus {
+  background: rgba(98,100,167,.8);
+}
+.desktop-capturer-selection__thumbnail {
+  width: 100%;
+  height: 81px;
+  object-fit: cover;
+}
+.desktop-capturer-selection__name {
+  margin: 6px 0 6px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+`;
 
 class RecipeController {
   @observable settings = {
@@ -117,14 +180,15 @@ class RecipeController {
   }
 
   async loadUserFiles(recipe, config) {
+    const styles = document.createElement('style');
+    styles.innerHTML = screenShareCss;
+
     const userCss = path.join(recipe.path, 'user.css');
     if (await fs.exists(userCss)) {
       const data = await fs.readFile(userCss);
-      const styles = document.createElement('style');
-      styles.innerHTML = data.toString();
-
-      document.querySelector('head').appendChild(styles);
+      styles.innerHTML += data.toString();
     }
+    document.querySelector('head').appendChild(styles);
 
     const userJs = path.join(recipe.path, 'user.js');
     if (await fs.exists(userJs)) {
@@ -372,3 +436,60 @@ window.open = (url, frameName, features) => {
 if (isDevMode) {
   window.log = console.log;
 }
+
+// Patch getDisplayMedia for screen sharing
+window.navigator.mediaDevices.getDisplayMedia = () => new Promise(async (resolve, reject) => {
+  try {
+    const sources = await desktopCapturer.getSources({ types: ['screen', 'window'] });
+
+    const selectionElem = document.createElement('div');
+    selectionElem.classList = 'desktop-capturer-selection';
+    selectionElem.innerHTML = `
+        <div class="desktop-capturer-selection__scroller">
+          <ul class="desktop-capturer-selection__list">
+            ${sources.map(({
+    id, name, thumbnail,
+  }) => `
+              <li class="desktop-capturer-selection__item">
+                <button class="desktop-capturer-selection__btn" data-id="${id}" title="${name}">
+                  <img class="desktop-capturer-selection__thumbnail" src="${thumbnail.toDataURL()}" />
+                  <span class="desktop-capturer-selection__name">${name}</span>
+                </button>
+              </li>
+            `).join('')}
+          </ul>
+        </div>
+      `;
+    document.body.appendChild(selectionElem);
+
+    document.querySelectorAll('.desktop-capturer-selection__btn')
+      .forEach((button) => {
+        button.addEventListener('click', async () => {
+          try {
+            const id = button.getAttribute('data-id');
+            const mediaSource = sources.find(source => source.id === id);
+            if (!mediaSource) {
+              throw new Error(`Source with id ${id} does not exist`);
+            }
+
+            const stream = await window.navigator.mediaDevices.getUserMedia({
+              audio: false,
+              video: {
+                mandatory: {
+                  chromeMediaSource: 'desktop',
+                  chromeMediaSourceId: mediaSource.id,
+                },
+              },
+            });
+            resolve(stream);
+
+            selectionElem.remove();
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+  } catch (err) {
+    reject(err);
+  }
+});


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->
Inject css and js for all service to make is usable with screen share.

Seems like Skype and Teams work, but Google Meet fails as it does not even get to `getDisplaymedia` which is missing in case of electron, seems like it is testing some other api and fail

Someone has to verify with the services they like to use with this.

@kytwb I am not sure if the code style is fine, or should we even inject this globally, lets keep this PR as WIP until we finalize this.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It lets you use screen sharing with all service that supports screen sharing. 

#463 #777

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [ ] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally