### PR TITLE
Remove Ferdi string from default user agent

### DIFF
--- a/src/helpers/userAgent-helpers.js
+++ b/src/helpers/userAgent-helpers.js
@@ -22,7 +22,7 @@ function linux() {
   return 'X11; Linux x86_64';
 }
 
-export default function userAgent(removeChromeVersion = false) {
+export default function userAgent(removeChromeVersion = false, addFerdiVersion = false) {
   let platformString = '';
 
   if (isMac) {
@@ -39,7 +39,7 @@ export default function userAgent(removeChromeVersion = false) {
   }
 
   let applicationString = '';
-  if (!removeChromeVersion) {
+  if (addFerdiVersion) {
     applicationString = ` Ferdi/${ferdiVersion} Electron/${process.versions.electron}`;
   }
 


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->
It seems that most websites don't like the additional `Ferdi/<version> Electron/<version>` string in the user agent used by Ferdi. I propose that we remove this, to mimic what Chrome would send to websites.

This would remove the need to make recipe-specific hacks to the user agent such as in Gmail - https://github.com/getferdi/recipes/blob/1498743f99625b574b51cee061a70bf271da93b7/uncompressed/gmail/index.js#L9

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getferdi/ferdi/issues/788 and fixes https://github.com/getferdi/ferdi/issues/790

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally