### PR TITLE
Update adaptable dark mode to work on all platforms

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -12,7 +12,7 @@ import PremiumFeatureContainer from '../../ui/PremiumFeatureContainer';
 import Input from '../../ui/Input';
 
 import { FRANZ_TRANSLATION } from '../../../config';
-import { isMac, isWindows } from '../../../environment';
+import { isMac } from '../../../environment';
 
 const {
   systemPreferences,
@@ -468,8 +468,8 @@ export default @observer class EditSettingsForm extends Component {
 
                 <Hr />
 
-                {(isMac || isWindows) && <Toggle field={form.$('adaptableDarkMode')} />}
-                {!((isMac || isWindows) && isAdaptableDarkModeEnabled) && <Toggle field={form.$('darkMode')} />}
+                <Toggle field={form.$('adaptableDarkMode')} />
+                {!isAdaptableDarkModeEnabled && <Toggle field={form.$('darkMode')} />}
                 {(isDarkmodeEnabled || isAdaptableDarkModeEnabled) && (
                 <>
                   <Toggle field={form.$('universalDarkMode')} />

--- a/src/index.js
+++ b/src/index.js
@@ -332,7 +332,7 @@ const createWindow = () => {
     e.preventDefault();
 
     if (isValidExternalURL(url)) {
-        shell.openExternal(url);
+      shell.openExternal(url);
     }
   });
 
@@ -411,10 +411,10 @@ ipcMain.on('feature-basic-auth-credentials', (e, { user, password }) => {
   authCallback = noop;
 });
 
-ipcMain.on('open-browser-window', (e, {disposition, url}, serviceId) => {
+ipcMain.on('open-browser-window', (e, { disposition, url }, serviceId) => {
   if (disposition === 'foreground-tab') {
-    let serviceSession = session.fromPartition(`persist:service-${serviceId}`)
-    let child = new BrowserWindow({ parent: mainWindow, webPreferences: {session: serviceSession}});
+    const serviceSession = session.fromPartition(`persist:service-${serviceId}`);
+    const child = new BrowserWindow({ parent: mainWindow, webPreferences: { session: serviceSession } });
     child.show();
     child.loadURL(url);
   }

--- a/src/stores/UIStore.js
+++ b/src/stores/UIStore.js
@@ -12,9 +12,7 @@ const { nativeTheme, systemPreferences } = remote;
 export default class UIStore extends Store {
   @observable showServicesUpdatedInfoBar = false;
 
-  @observable isOsDarkThemeActive = (isMac || isWindows)
-    ? nativeTheme.shouldUseDarkColors
-    : false;
+  @observable isOsDarkThemeActive = nativeTheme.shouldUseDarkColors;
 
   constructor(...args) {
     super(...args);
@@ -63,16 +61,14 @@ export default class UIStore extends Store {
   }
 
   @computed get isDarkThemeActive() {
-    const isMacOrWindowsWithAdaptableInDarkMode = (isMac || isWindows)
-      && this.stores.settings.all.app.adaptableDarkMode
+    const isWithAdaptableInDarkMode = this.stores.settings.all.app.adaptableDarkMode
       && this.isOsDarkThemeActive;
-    const isMacOrWindowsWithoutAdaptableInDarkMode = (isMac || isWindows)
-      && this.stores.settings.all.app.darkMode
+    const isWithoutAdaptableInDarkMode = this.stores.settings.all.app.darkMode
       && !this.stores.settings.all.app.adaptableDarkMode;
-    const isMacOrWindowsNotInDarkMode = !(isMac || isWindows) && this.stores.settings.all.app.darkMode;
-    return !!(isMacOrWindowsWithAdaptableInDarkMode
-      || isMacOrWindowsWithoutAdaptableInDarkMode
-      || isMacOrWindowsNotInDarkMode);
+    const isNotInDarkMode = this.stores.settings.all.app.darkMode;
+    return !!(isWithAdaptableInDarkMode
+      || isWithoutAdaptableInDarkMode
+      || isNotInDarkMode);
   }
 
   @computed get theme() {

--- a/src/stores/UIStore.js
+++ b/src/stores/UIStore.js
@@ -65,10 +65,10 @@ export default class UIStore extends Store {
       && this.isOsDarkThemeActive;
     const isWithoutAdaptableInDarkMode = this.stores.settings.all.app.darkMode
       && !this.stores.settings.all.app.adaptableDarkMode;
-    const isNotInDarkMode = this.stores.settings.all.app.darkMode;
+    const isInDarkMode = this.stores.settings.all.app.darkMode;
     return !!(isWithAdaptableInDarkMode
       || isWithoutAdaptableInDarkMode
-      || isNotInDarkMode);
+      || isInDarkMode);
   }
 
   @computed get theme() {


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail. -->
Currently, adaptable dark mode is only available on Windows and Mac. Looking at Electrons documentation (https://www.electronjs.org/docs/api/native-theme#nativethemeshouldusedarkcolors-readonly) it looks like there isn't any restriction to those OSs. This PR will remove Ferdi's restriction to only showing the adaptable dark mode option on Windows and Mac.

Closes #833.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My pull request is properly named
- [ ] The changes respect the code style of the project (`$ npm run lint`)
- [ ] I tested/previewed my changes locally