### PR TITLE
Add recipes packaging to development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,15 @@ If you previously ran `npm install` it sometimes is necessary to delete your `no
 $ npm run rebuild
 ```
 
+### Package recipe repository
+
+Ferdi requires its recipes to be packaged before it can use it. When running Ferdi as a development instance, you'll need to package the local recipes before you can create any services inside Ferdi.
+
+```bash
+$ cd recipes
+$ npm install && npm run package
+```
+
 ### Start development app
 
 Run these two commands **simultaneously** in different terminals:


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->

I've been having some problems setting up a development instance because I couldn't get recipes to work. Turns out its because our recipes aren't packaged anymore by default.

This PR will add the recipe packaging as a step to our development setup guide.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally