### PR TITLE
Fix "Open folder" button on "Custom services" screen

### DIFF
--- a/src/containers/settings/RecipesScreen.js
+++ b/src/containers/settings/RecipesScreen.js
@@ -163,7 +163,7 @@ export default @inject('stores', 'actions') @observer class RecipesScreen extend
           recipeDirectory={recipeDirectory}
           openRecipeDirectory={async () => {
             await fs.ensureDir(recipeDirectory);
-            shell.openExternal('file://' + recipeDirectory);
+            shell.openExternal(`file://${recipeDirectory}`);
           }}
           openDevDocs={() => {
             appActions.openExternalUrl({ url: FRANZ_DEV_DOCS });

--- a/src/containers/settings/RecipesScreen.js
+++ b/src/containers/settings/RecipesScreen.js
@@ -163,7 +163,7 @@ export default @inject('stores', 'actions') @observer class RecipesScreen extend
           recipeDirectory={recipeDirectory}
           openRecipeDirectory={async () => {
             await fs.ensureDir(recipeDirectory);
-            shell.openItem(recipeDirectory);
+            shell.openExternal('file://' + recipeDirectory);
           }}
           openDevDocs={() => {
             appActions.openExternalUrl({ url: FRANZ_DEV_DOCS });


### PR DESCRIPTION
### Description
<!-- Describe your changes in detail. -->
While trying to develop a recipe I noticed that the "Open folder" button on the "Custom services" screen to open the dev recipes folder doesn't seem to work anymore.

The error is "shell.openItem is not a function". Looking at the Electron docs (https://www.electronjs.org/docs/api/shell) it looks like "shell.openItem" is no longer part of the API and should be replaced with "shell.openExternal" and "file://".

This seems to work on macOS, maybe someone can test if this also works on other platforms?

### Screenshots
<!-- Remove the section if this does not apply. -->

<img width="1530" alt="Screenshot 2020-10-03 at 12 21 23" src="https://user-images.githubusercontent.com/10333196/94989244-8ffc8100-0573-11eb-86de-385c125156d0.png">


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally