### PR TITLE
Add custom website information to recipe dashboard

### DIFF
--- a/src/components/settings/recipes/RecipesDashboard.js
+++ b/src/components/settings/recipes/RecipesDashboard.js
@@ -15,6 +15,7 @@ import Appear from '../../ui/effects/Appear';
 import { FRANZ_SERVICE_REQUEST } from '../../../config';
 import LimitReachedInfobox from '../../../features/serviceLimit/components/LimitReachedInfobox';
 import PremiumFeatureContainer from '../../ui/PremiumFeatureContainer';
+import RecipePreview from '../../../models/RecipePreview';
 
 const messages = defineMessages({
   headline: {
@@ -39,7 +40,7 @@ const messages = defineMessages({
   },
   nothingFound: {
     id: 'settings.recipes.nothingFound',
-    defaultMessage: '!!!Sorry, but no service matched your search term.',
+    defaultMessage: '!!!Sorry, but no service matched your search term - but you can still probably add it using the "Custom Website" option:',
   },
   servicesSuccessfulAddedInfo: {
     id: 'settings.recipes.servicesSuccessfulAddedInfo',
@@ -106,6 +107,7 @@ const styles = {
 export default @injectSheet(styles) @observer class RecipesDashboard extends Component {
   static propTypes = {
     recipes: MobxPropTypes.arrayOrObservableArray.isRequired,
+    customWebsiteRecipe: PropTypes.instanceOf(RecipePreview).isRequired,
     isLoading: PropTypes.bool.isRequired,
     hasLoadedRecipes: PropTypes.bool.isRequired,
     showAddServiceInterface: PropTypes.func.isRequired,
@@ -133,6 +135,7 @@ export default @injectSheet(styles) @observer class RecipesDashboard extends Com
   render() {
     const {
       recipes,
+      customWebsiteRecipe,
       isLoading,
       hasLoadedRecipes,
       showAddServiceInterface,
@@ -256,12 +259,19 @@ export default @injectSheet(styles) @observer class RecipesDashboard extends Com
                 )}
                 <div className="recipes__list">
                   {hasLoadedRecipes && recipes.length === 0 && recipeFilter !== 'dev' && (
-                    <p className="align-middle settings__empty-state">
+                    <div className="align-middle settings__empty-state">
                       <span className="emoji">
                         <img src="./assets/images/emoji/dontknow.png" alt="" />
                       </span>
-                      {intl.formatMessage(messages.nothingFound)}
-                    </p>
+
+                      <p className="settings__empty-state-text">{intl.formatMessage(messages.nothingFound)}</p>
+                      
+                      <RecipeItem
+                        key={customWebsiteRecipe.id}
+                        recipe={customWebsiteRecipe}
+                        onClick={() => isLoggedIn && showAddServiceInterface({ recipeId: customWebsiteRecipe.id })}
+                      />
+                    </div>
                   )}
                   {communityRecipes.map(recipe => (
                     <RecipeItem

--- a/src/containers/settings/RecipesScreen.js
+++ b/src/containers/settings/RecipesScreen.js
@@ -139,6 +139,8 @@ export default @inject('stores', 'actions') @observer class RecipesScreen extend
       ),
     ]) : recipeFilter;
 
+    const customWebsiteRecipe = recipePreviews.all.find(service => service.id === 'franz-custom-website');
+
     const isLoading = recipePreviews.featuredRecipePreviewsRequest.isExecuting
       || recipePreviews.allRecipePreviewsRequest.isExecuting
       || recipes.installRecipeRequest.isExecuting
@@ -150,6 +152,7 @@ export default @inject('stores', 'actions') @observer class RecipesScreen extend
       <ErrorBoundary>
         <RecipesDashboard
           recipes={allRecipes}
+          customWebsiteRecipe={customWebsiteRecipe}
           isLoading={isLoading}
           addedServiceCount={services.all.length}
           isPremium={user.data.isPremium}

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -2296,182 +2296,182 @@
         "defaultMessage": "!!!Available Services",
         "end": {
           "column": 3,
-          "line": 23
+          "line": 24
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.headline",
         "start": {
           "column": 12,
-          "line": 20
+          "line": 21
         }
       },
       {
         "defaultMessage": "!!!Search service",
         "end": {
           "column": 3,
-          "line": 27
+          "line": 28
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.searchService",
         "start": {
           "column": 17,
-          "line": 24
+          "line": 25
         }
       },
       {
         "defaultMessage": "!!!Most popular",
         "end": {
           "column": 3,
-          "line": 31
+          "line": 32
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.mostPopular",
         "start": {
           "column": 22,
-          "line": 28
+          "line": 29
         }
       },
       {
         "defaultMessage": "!!!All services",
         "end": {
           "column": 3,
-          "line": 35
+          "line": 36
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.all",
         "start": {
           "column": 14,
-          "line": 32
+          "line": 33
         }
       },
       {
         "defaultMessage": "!!!Custom Services",
         "end": {
           "column": 3,
-          "line": 39
+          "line": 40
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.custom",
         "start": {
           "column": 17,
-          "line": 36
+          "line": 37
         }
       },
       {
-        "defaultMessage": "!!!Sorry, but no service matched your search term.",
+        "defaultMessage": "!!!Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
         "end": {
           "column": 3,
-          "line": 43
+          "line": 44
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.nothingFound",
         "start": {
           "column": 16,
-          "line": 40
+          "line": 41
         }
       },
       {
         "defaultMessage": "!!!Service successfully added",
         "end": {
           "column": 3,
-          "line": 47
+          "line": 48
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.servicesSuccessfulAddedInfo",
         "start": {
           "column": 31,
-          "line": 44
+          "line": 45
         }
       },
       {
         "defaultMessage": "!!!Missing a service?",
         "end": {
           "column": 3,
-          "line": 51
+          "line": 52
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.missingService",
         "start": {
           "column": 18,
-          "line": 48
+          "line": 49
         }
       },
       {
         "defaultMessage": "!!!To add a custom service, copy the recipe folder into:",
         "end": {
           "column": 3,
-          "line": 55
+          "line": 56
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.customService.intro",
         "start": {
           "column": 21,
-          "line": 52
+          "line": 53
         }
       },
       {
         "defaultMessage": "!!!Open directory",
         "end": {
           "column": 3,
-          "line": 59
+          "line": 60
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.customService.openFolder",
         "start": {
           "column": 14,
-          "line": 56
+          "line": 57
         }
       },
       {
         "defaultMessage": "!!!Developer Documentation",
         "end": {
           "column": 3,
-          "line": 63
+          "line": 64
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.customService.openDevDocs",
         "start": {
           "column": 15,
-          "line": 60
+          "line": 61
         }
       },
       {
         "defaultMessage": "!!!Custom 3rd Party Recipes",
         "end": {
           "column": 3,
-          "line": 67
+          "line": 68
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.customService.headline.customRecipes",
         "start": {
           "column": 25,
-          "line": 64
+          "line": 65
         }
       },
       {
         "defaultMessage": "!!!Community 3rd Party Recipes",
         "end": {
           "column": 3,
-          "line": 71
+          "line": 72
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.customService.headline.communityRecipes",
         "start": {
           "column": 28,
-          "line": 68
+          "line": 69
         }
       },
       {
         "defaultMessage": "!!!Your Development Service Recipes",
         "end": {
           "column": 3,
-          "line": 75
+          "line": 76
         },
         "file": "src/components/settings/recipes/RecipesDashboard.js",
         "id": "settings.recipes.customService.headline.devRecipes",
         "start": {
           "column": 22,
-          "line": 72
+          "line": 73
         }
       }
     ],

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -363,7 +363,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term.",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/messages/src/components/settings/recipes/RecipesDashboard.json
+++ b/src/i18n/messages/src/components/settings/recipes/RecipesDashboard.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Available Services",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 20,
+      "line": 21,
       "column": 12
     },
     "end": {
-      "line": 23,
+      "line": 24,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!Search service",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 24,
+      "line": 25,
       "column": 17
     },
     "end": {
-      "line": 27,
+      "line": 28,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Most popular",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 28,
+      "line": 29,
       "column": 22
     },
     "end": {
-      "line": 31,
+      "line": 32,
       "column": 3
     }
   },
@@ -43,11 +43,11 @@
     "defaultMessage": "!!!All services",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 32,
+      "line": 33,
       "column": 14
     },
     "end": {
-      "line": 35,
+      "line": 36,
       "column": 3
     }
   },
@@ -56,24 +56,24 @@
     "defaultMessage": "!!!Custom Services",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 36,
+      "line": 37,
       "column": 17
     },
     "end": {
-      "line": 39,
+      "line": 40,
       "column": 3
     }
   },
   {
     "id": "settings.recipes.nothingFound",
-    "defaultMessage": "!!!Sorry, but no service matched your search term.",
+    "defaultMessage": "!!!Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 40,
+      "line": 41,
       "column": 16
     },
     "end": {
-      "line": 43,
+      "line": 44,
       "column": 3
     }
   },
@@ -82,11 +82,11 @@
     "defaultMessage": "!!!Service successfully added",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 44,
+      "line": 45,
       "column": 31
     },
     "end": {
-      "line": 47,
+      "line": 48,
       "column": 3
     }
   },
@@ -95,11 +95,11 @@
     "defaultMessage": "!!!Missing a service?",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 48,
+      "line": 49,
       "column": 18
     },
     "end": {
-      "line": 51,
+      "line": 52,
       "column": 3
     }
   },
@@ -108,11 +108,11 @@
     "defaultMessage": "!!!To add a custom service, copy the recipe folder into:",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 52,
+      "line": 53,
       "column": 21
     },
     "end": {
-      "line": 55,
+      "line": 56,
       "column": 3
     }
   },
@@ -121,11 +121,11 @@
     "defaultMessage": "!!!Open directory",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 56,
+      "line": 57,
       "column": 14
     },
     "end": {
-      "line": 59,
+      "line": 60,
       "column": 3
     }
   },
@@ -134,11 +134,11 @@
     "defaultMessage": "!!!Developer Documentation",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 60,
+      "line": 61,
       "column": 15
     },
     "end": {
-      "line": 63,
+      "line": 64,
       "column": 3
     }
   },
@@ -147,11 +147,11 @@
     "defaultMessage": "!!!Custom 3rd Party Recipes",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 64,
+      "line": 65,
       "column": 25
     },
     "end": {
-      "line": 67,
+      "line": 68,
       "column": 3
     }
   },
@@ -160,11 +160,11 @@
     "defaultMessage": "!!!Community 3rd Party Recipes",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 68,
+      "line": 69,
       "column": 28
     },
     "end": {
-      "line": 71,
+      "line": 72,
       "column": 3
     }
   },
@@ -173,11 +173,11 @@
     "defaultMessage": "!!!Your Development Service Recipes",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
-      "line": 72,
+      "line": 73,
       "column": 22
     },
     "end": {
-      "line": 75,
+      "line": 76,
       "column": 3
     }
   }

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -330,6 +330,10 @@
     text-align: center;
     width: 100%;
 
+    .settings__empty-state-text {
+      margin-bottom: 1em;
+    }
+
     a.button { margin-top: 40px; }
   }
 


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->

It looks like many people don't know about the "Custom Website" option in Ferdi and will instead suggest a new recipe or quit using Ferdi frustrated.

This PR will add information about the existence of the "Custom Website" option when searching for an unknown service:

<img width="1552" alt="Screenshot 2020-10-04 at 16 58 17" src="https://user-images.githubusercontent.com/10333196/95018980-0b892b80-0663-11eb-8a06-3f9a7e01694e.png">

The user can simply click on the "Custom Website" entry to add the new service.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally