### PR TITLE
Flash TaskBar (Windows) / Bounce Dock (Mac) on New Message

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -306,6 +306,8 @@ export default @observer class EditSettingsForm extends Component {
                   <Toggle field={form.$('minimizeToSystemTray')} />
                 )}
                 <Toggle field={form.$('privateNotifications')} />
+                {(process.platform === 'win32' || process.platform === 'darwin') && (
+                  <Toggle field={form.$('notifyTaskBarOnMessage')} />)}
                 <Select field={form.$('navigationBarBehaviour')} />
 
                 <Hr />

--- a/src/config.js
+++ b/src/config.js
@@ -94,6 +94,7 @@ export const DEFAULT_APP_SETTINGS = {
   startMinimized: false,
   minimizeToSystemTray: false,
   privateNotifications: false,
+  notifyTaskBarOnMessage: false,
   showDisabledServices: true,
   showMessageBadgeWhenMuted: true,
   showDragArea: false,

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -59,6 +59,10 @@ const messages = defineMessages({
     id: 'settings.app.form.privateNotifications',
     defaultMessage: '!!!Don\'t show message content in notifications',
   },
+  notifyTaskBarOnMessage: {
+    id: 'settings.app.form.notifyTaskBarOnMessage',
+    defaultMessage: '!!!Notify TaskBar/Dock on new message',
+  },
   navigationBarBehaviour: {
     id: 'settings.app.form.navigationBarBehaviour',
     defaultMessage: '!!!Navigation bar behaviour',
@@ -230,6 +234,7 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
         startMinimized: settingsData.startMinimized,
         minimizeToSystemTray: settingsData.minimizeToSystemTray,
         privateNotifications: settingsData.privateNotifications,
+        notifyTaskBarOnMessage: settingsData.notifyTaskBarOnMessage,
         navigationBarBehaviour: settingsData.navigationBarBehaviour,
         sentry: settingsData.sentry,
         hibernate: settingsData.hibernate,
@@ -373,6 +378,11 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           label: intl.formatMessage(messages.privateNotifications),
           value: settings.all.app.privateNotifications,
           default: DEFAULT_APP_SETTINGS.privateNotifications,
+        },
+        notifyTaskBarOnMessage: {
+          label: intl.formatMessage(messages.notifyTaskBarOnMessage),
+          value: settings.all.app.notifyTaskBarOnMessage,
+          default: DEFAULT_APP_SETTINGS.notifyTaskBarOnMessage,
         },
         navigationBarBehaviour: {
           label: intl.formatMessage(messages.navigationBarBehaviour),

--- a/src/electron/ipc-api/appIndicator.js
+++ b/src/electron/ipc-api/appIndicator.js
@@ -25,6 +25,19 @@ export default (params) => {
   });
 
   ipcMain.on('updateAppIndicator', (event, args) => {
+
+    // Flash TaskBar for windows, bounce Dock on Mac
+    if (!app.mainWindow.isFocused()) {
+      if (params.settings.app.get('notifyTaskBarOnMessage')) {
+        if (process.platform === 'win32') {
+          app.mainWindow.flashFrame(true);
+          app.mainWindow.once('focus', () => app.mainWindow.flashFrame(false));
+        } else if (process.platform === 'darwin') {
+          app.dock.bounce('informational');
+        }
+      }
+    }
+
     // Update badge
     if (process.platform === 'darwin'
       && typeof (args.indicator) === 'string') {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -311,6 +311,7 @@
   "settings.app.form.navigationBarBehaviour": "Navigation bar behaviour",
   "settings.app.form.predefinedTodoServer": "Todo Server",
   "settings.app.form.privateNotifications": "Don't show message content in notifications",
+  "settings.app.form.notifyTaskBarOnMessage": "Notify TaskBar/Dock on new message",
   "settings.app.form.reloadAfterResume": "Reload Ferdi after system resume",
   "settings.app.form.runInBackground": "Keep Ferdi in background when closing the window",
   "settings.app.form.scheduledDNDEnabled": "Enable scheduled Do-not-Disturb",


### PR DESCRIPTION

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->
Whenever a new message arrives in Ferdi, Flash the TaskBar in Windows or bounce the dock on Mac. This happens only when the Active Window is not in Focus. Once the Window is brought to focus, we don't perform this functionality.

- Update config to include 'notifyTaskBarOnMessage' - defaults to False
- Add a new Toggle Field for Win32 and MacOS for NotifyTaskBarOnMessage in EditSettingsForm.js
- Add notifyTaskbarOnMessage under messages Array in EditSettingsScreen.js
- Update appIndicator.js to flash Windows TaskBar or Bounce the Dock on MacOS when a new message arrives
- Update en-US.json to include settings.app.form.notifyTaskBarOnMessage string

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This feature is a result of a new Feature request - #897  . Most windows users switch off the default notification system which is sometimes annoying. Having this functionality will let the users know that a new message has arrived in Ferdi.

### Screenshots
<!-- Remove the section if this does not apply. -->
![image](https://user-images.githubusercontent.com/1255523/95830953-0bb9b300-0d56-11eb-8503-fc4e9dc3bc3f.png)

![image](https://user-images.githubusercontent.com/1255523/95839567-ca7ad080-0d60-11eb-9ba4-b1d177bc86c0.png)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally on Windows. 
- [ ] Need to test this on MacOS