### PR TITLE
Add Danish to the list of available languages

### DIFF
--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -3,6 +3,7 @@ export const APP_LOCALES = {
   ca: 'Català',
   'zh-HANT': '中文 (Chinese Traditional)',
   cs: 'Čeština',
+  da: 'Dansk',
   nl: 'Nederlands',
   fr: 'Français',
   ka: 'ქართული (Georgian)',


### PR DESCRIPTION
### Description
Add Danish (`da: Dansk`) to the list of available languages. Not sure if more needs to be done to enable it?

### Motivation and Context
Ferdi is now (after https://github.com/getferdi/ferdi/pull/1048) 100% translated to Danish, mostly by myself, but also reviewed a bit by some other contributors.

### Checklist:
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [ ] I tested/previewed my changes locally
    - Haven't done this, my development environment isn't fully set up yet
