### PR TITLE
Remove obsolete Franz references from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,7 @@
 This project and everyone participating in it is governed by the [Ferdi Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [stefan@adlk.io](mailto:stefan@adlk.io).
 
 ## What should I know before I get started?
-With Ferdi 5, we have completely separated the client and the services. If you have any issues with a service recipe, please do not open an issue at this repository. Instead head over to the [Ferdi Recipe Repository](https://github.com/meetfranz/plugins) and open a new issue there.
-
-If you need help with development, want to discuss a new feature or improvement please talk to us either on [Slack](http://slack.franz.im) or open a new issue with the [feature proposal template](.github/FEATURE_PROPOSAL_TEMPLATE.md).
+For the moment, Ferdi's development is a bit slow but all contributions are highly appreciated. [Check this issue for discussion](https://github.com/getferdi/ferdi/issues/956).
 
 ## How Can I Contribute?
 As a basic rule, before filing issues, feature requests or anything else. Take a look at the issues and check if this has not already been reported by another user. If so, engage in the already existing discussion.


### PR DESCRIPTION
Remove obsolete Franz references.

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->
I removed old Franz references from CONTRIBUTING.md and added a link to the issue discussing the current state of development.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Because the previous links point to Franz's Slack which is definitely the wrong place to talk about Ferdi.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally