### PR TITLE
Show username and lastname fetched from server in account settings

### DIFF
--- a/src/components/settings/account/AccountDashboard.js
+++ b/src/components/settings/account/AccountDashboard.js
@@ -209,7 +209,7 @@ class AccountDashboard extends Component {
                           </div>
                           <div className="account__info">
                             <H1>
-                              <span className="username">{`${user.firstname} ${isUsingFranzServer ? user.lastname : ''}`}</span>
+                              <span className="username">{`${user.firstname} ${user.lastname}`}</span>
                               {user.isPremium && (
                                 <>
                                   {' '}


### PR DESCRIPTION
### Description
This pull request fixes issue [https://github.com/getferdi/ferdi/issues/1040](https://github.com/getferdi/ferdi/issues/1040). The changes in the `getferdi/ferdi` repository are not big -> it is just one small change in `AccountDashboard` to use data fetched via API from the server. Most of the changes are in `getferdi/server` repository and this pull request depends on the merging of [https://github.com/getferdi/server/pull/50](https://github.com/getferdi/server/pull/50) pull request that's why I marked it as draft for now. 

### Motivation and Context
It fixes  [https://github.com/getferdi/ferdi/issues/1040](https://github.com/getferdi/ferdi/issues/1040).

### Screenshots
![2021-02-06-201509_1920x1080_scrot](https://user-images.githubusercontent.com/6313392/107127711-3e188e80-68b8-11eb-9034-b4c4560f7226.png)


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally