### PR TITLE
Displays search input when service is not found

### DIFF
--- a/src/components/settings/services/ServicesDashboard.js
+++ b/src/components/settings/services/ServicesDashboard.js
@@ -95,7 +95,7 @@ export default @observer class ServicesDashboard extends Component {
         </div>
         <LimitReachedInfobox />
         <div className="settings__body">
-          {services.length !== 0 && !isLoading && (
+          {(services.length !== 0 || searchNeedle) && !isLoading && (
             <SearchInput
               placeholder={intl.formatMessage(messages.searchService)}
               onChange={needle => filterServices({ needle })}


### PR DESCRIPTION
### Description
display search input when not finding the service searched

### Motivation and Context
I found a problem when I did not find the service I was looking for then the search input will disappear, I have to go to another page to display the search input and list service.
I'm trying to fix that

### Screenshots
**Before**
![image](https://user-images.githubusercontent.com/1139881/108490254-1e7c5f80-72d5-11eb-91ae-f9d7e7bb558a.png)

**After**
![image](https://user-images.githubusercontent.com/1139881/108490161-01479100-72d5-11eb-8a09-f3c028e29cf3.png)

![image](https://user-images.githubusercontent.com/1139881/108490379-466bc300-72d5-11eb-9474-4222e047a8d4.png)

### Checklist:
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally