### PR TITLE
Fixes "Service Developer Tools not available" #147

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -860,8 +860,6 @@ export default class FranzMenu {
         accelerator: `${cmdKey}+Shift+Alt+I`,
         click: () => {
           this.actions.service.openDevToolsForActiveService();
-          const webview = document.querySelector('#todos-panel webview');
-          if (webview) this.actions.todos.openDevTools();
         },
         enabled: this.stores.user.isLoggedIn && this.stores.services.enabled.length > 0,
       });
@@ -871,8 +869,8 @@ export default class FranzMenu {
           label: intl.formatMessage(menuItems.toggleTodosDevTools),
           accelerator: `${cmdKey}+Shift+Alt+O`,
           click: () => {
-            const webview = document.querySelector('webview[partition="persist:todos"]');
-            if (webview) webview.openDevTools();
+            const webview = document.querySelector('#todos-panel webview');
+            if (webview) this.actions.todos.openDevTools();
           },
         });
       }


### PR DESCRIPTION
### Description
I have managed to reproduce the issue #147 and after I did compare with the code in franz there was a difference, this possibility occurred while doing the merge that has been past.
https://github.com/meetfranz/franz/blob/master/src/lib/Menu.js#L664-L675
i've fixed some line code and different and now devtools for todo list is already working 

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally