### PR TITLE
Change Search with Google link in context menu

### DIFF
--- a/src/webview/contextMenuBuilder.js
+++ b/src/webview/contextMenuBuilder.js
@@ -275,7 +275,7 @@ module.exports = class ContextMenuBuilder {
     const search = new MenuItem({
       label: this.stringTable.searchGoogle(),
       click: () => {
-        const url = `https://www.google.com/#q=${encodeURIComponent(menuInfo.selectionText)}`;
+        const url = `https://www.google.com/search?q=${encodeURIComponent(menuInfo.selectionText)}`;
 
         shell.openExternal(url);
       },


### PR DESCRIPTION
### Description
Change the Google Search link in the context menu from
https://www.google.com/#q=searchterm
to
https://www.google.com/search?q=searchterm

### Motivation and Context
At the moment when clicking on the "Search with Google" link in the context menu it opens
https://www.google.com/#q=searchterm
which doesn't seem to work, so changing it to this
https://www.google.com/search?q=searchterm
should solve this issue

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally