### PR TITLE
Fix window unsnapping when clicking notification (#896)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,9 @@ if (!gotTheLock) {
   app.on('second-instance', (event, argv) => {
     // Someone tried to run a second instance, we should focus our window.
     if (mainWindow) {
-      mainWindow.show();
+      if (!mainWindow.isVisible()) {
+        mainWindow.show();
+      }
       if (mainWindow.isMinimized()) {
         mainWindow.restore();
       }

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -333,7 +333,9 @@ export default class AppStore extends Store {
         this.actions.service.setActive({
           serviceId,
         });
-        mainWindow.show();
+        if (!app.mainWindow.isVisible()) {
+          mainWindow.show();
+        }
         if (app.mainWindow.isMinimized()) {
           mainWindow.restore();
         }


### PR DESCRIPTION
### Description
Previously when Ferdi was docked to the side of the screen and the user clicked on a Windows 10 notification the window would move/resize. This pull request fixes the issue (#896) by being less aggressive about focusing the window.

The changes have been tested on Windows 10 20H2 and Ubuntu 20.04.

### Checklist:
- [x] My pull request is properly named
- [x] I tested/previewed my changes locally
- [x] The changes respect the code style of the project (`$ npm run lint`)
