### PR TITLE
Removed electron-process-manager since its no longer supported by Ele…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10782,6 +10782,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
       "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -12170,35 +12171,6 @@
         }
       }
     },
-    "electron-process-manager": {
-      "version": "git+https://git@github.com/dizer/electron-process-manager.git#6700fc0d777aca55d1a891add363996c281a0874",
-      "from": "git+https://git@github.com/dizer/electron-process-manager.git"
-    },
-    "electron-process-reporter": {
-      "version": "git+https://git@github.com/dizer/electron-process-reporter.git#6c4b68572ecc7e76b60459a7b03a411c8c139fd4",
-      "from": "git+https://git@github.com/dizer/electron-process-reporter.git",
-      "requires": {
-        "memoizee": "^0.4.14",
-        "pidtree": "^0.3.0",
-        "pidusage": "2.0.16",
-        "rxjs": "^5.5.6"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "5.5.12",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
-          "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
-          "requires": {
-            "symbol-observable": "1.0.1"
-          }
-        },
-        "symbol-observable": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
-          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-        }
-      }
-    },
     "electron-publish": {
       "version": "22.10.5",
       "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.10.5.tgz",
@@ -13398,6 +13370,7 @@
       "version": "0.10.51",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
       "integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+      "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
@@ -13415,6 +13388,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -13440,6 +13414,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
       "integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+      "dev": true,
       "requires": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.51"
@@ -13449,6 +13424,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -13951,15 +13927,6 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
     },
     "event-stream": {
       "version": "3.3.4",
@@ -14478,21 +14445,6 @@
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
           "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
           "dev": true
-        }
-      }
-    },
-    "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
-      "requires": {
-        "type": "^2.0.0"
-      },
-      "dependencies": {
-        "type": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.1.0.tgz",
-          "integrity": "sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA=="
         }
       }
     },
@@ -22476,14 +22428,6 @@
         }
       }
     },
-    "lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
-      "requires": {
-        "es5-ext": "~0.10.2"
-      }
-    },
     "lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -22927,59 +22871,6 @@
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
-      }
-    },
-    "memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
-      "requires": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
-      },
-      "dependencies": {
-        "es5-ext": {
-          "version": "0.10.53",
-          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-          "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
-          "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
-          },
-          "dependencies": {
-            "next-tick": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-              "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-            }
-          }
-        },
-        "es6-symbol": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-          "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-          "requires": {
-            "d": "^1.0.1",
-            "ext": "^1.1.2"
-          }
-        },
-        "is-promise": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-          "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
-        },
-        "next-tick": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-          "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-        }
       }
     },
     "memory-fs": {
@@ -23675,7 +23566,8 @@
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -25710,19 +25602,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
-    },
-    "pidtree": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
-      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA=="
-    },
-    "pidusage": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.16.tgz",
-      "integrity": "sha512-9dhSBxpGvvpyycCukU8CqTqJ+YT8aVZ/AI1/hGWhU5nAAOs0zYBYMyIYBU/grKeCYuTS26TVllIRvf5vAfsgvw==",
-      "requires": {
-        "safe-buffer": "^5.1.2"
-      }
     },
     "pify": {
       "version": "3.0.0",
@@ -30378,15 +30257,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
-      }
-    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -30821,7 +30691,8 @@
     "type": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
-      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -76,8 +76,6 @@
     "electron-find": "1.0.6",
     "electron-hunspell": "1.1.1",
     "electron-is-dev": "1.1.0",
-    "electron-process-manager": "git+https://git@github.com/dizer/electron-process-manager.git",
-    "electron-process-reporter": "git+https://git@github.com/dizer/electron-process-reporter.git",
     "electron-react-titlebar": "0.8.2",
     "electron-updater": "4.3.5",
     "electron-util": "0.14.0",

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -172,7 +172,6 @@ export default @observer class EditSettingsForm extends Component {
     isDarkmodeEnabled: PropTypes.bool.isRequired,
     isAdaptableDarkModeEnabled: PropTypes.bool.isRequired,
     isNightlyEnabled: PropTypes.bool.isRequired,
-    openProcessManager: PropTypes.func.isRequired,
     hasAddedTodosAsService: PropTypes.bool.isRequired,
     isOnline: PropTypes.bool.isRequired,
   };
@@ -226,7 +225,6 @@ export default @observer class EditSettingsForm extends Component {
       automaticUpdates,
       hibernationEnabled,
       isDarkmodeEnabled,
-      openProcessManager,
       isTodosActivated,
       isNightlyEnabled,
       hasAddedTodosAsService,
@@ -589,16 +587,6 @@ export default @observer class EditSettingsForm extends Component {
                       loaded={!isClearingAllCache}
                     />
                   </p>
-                  <div style={{
-                    marginTop: 20,
-                  }}
-                  >
-                    <Button
-                      buttonType="secondary"
-                      label="Open Process Manager"
-                      onClick={openProcessManager}
-                    />
-                  </div>
                 </div>
               </div>
             )}

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -1,4 +1,3 @@
-import { ipcRenderer } from 'electron';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react';
@@ -296,10 +295,6 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
         todosActions.toggleTodosFeatureVisibility();
       }
     }
-  }
-
-  openProcessManager() {
-    ipcRenderer.send('openProcessManager');
   }
 
   prepareForm() {
@@ -629,7 +624,6 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           isTodosActivated={this.props.stores.todos.isFeatureEnabledByUser}
           isUsingCustomTodoService={this.props.stores.todos.isUsingCustomTodoService}
           isNightlyEnabled={this.props.stores.settings.app.nightly}
-          openProcessManager={() => this.openProcessManager()}
           hasAddedTodosAsService={services.isTodosServiceAdded}
           isOnline={app.isOnline}
         />

--- a/src/electron/ipc-api/index.js
+++ b/src/electron/ipc-api/index.js
@@ -2,7 +2,6 @@ import autoUpdate from './autoUpdate';
 import settings from './settings';
 import appIndicator from './appIndicator';
 import download from './download';
-import processManager from './processManager';
 import localServer from './localServer';
 import cld from './cld';
 import dnd from './dnd';
@@ -12,7 +11,6 @@ export default (params) => {
   autoUpdate(params);
   appIndicator(params);
   download(params);
-  processManager(params);
   localServer(params);
   cld(params);
   dnd();

--- a/src/electron/ipc-api/processManager.js
+++ b/src/electron/ipc-api/processManager.js
@@ -1,8 +1,0 @@
-import { ipcMain } from 'electron';
-import { openProcessManager } from 'electron-process-manager';
-
-export default () => {
-  ipcMain.on('openProcessManager', () => {
-    openProcessManager();
-  });
-};

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Launch Ferdi on start",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 31,
+      "line": 30,
       "column": 21
     },
     "end": {
-      "line": 34,
+      "line": 33,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!Open in background",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 35,
+      "line": 34,
       "column": 26
     },
     "end": {
-      "line": 38,
+      "line": 37,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Keep Ferdi in background when closing the window",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 39,
+      "line": 38,
       "column": 19
     },
     "end": {
-      "line": 42,
+      "line": 41,
       "column": 3
     }
   },
@@ -43,11 +43,11 @@
     "defaultMessage": "!!!Start minimized",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 43,
+      "line": 42,
       "column": 18
     },
     "end": {
-      "line": 46,
+      "line": 45,
       "column": 3
     }
   },
@@ -56,11 +56,11 @@
     "defaultMessage": "!!!Always show Ferdi in system tray",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 47,
+      "line": 46,
       "column": 20
     },
     "end": {
-      "line": 50,
+      "line": 49,
       "column": 3
     }
   },
@@ -69,11 +69,11 @@
     "defaultMessage": "!!!Reload Ferdi after system resume",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 51,
+      "line": 50,
       "column": 21
     },
     "end": {
-      "line": 54,
+      "line": 53,
       "column": 3
     }
   },
@@ -82,11 +82,11 @@
     "defaultMessage": "!!!Minimize Ferdi to system tray",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 55,
+      "line": 54,
       "column": 24
     },
     "end": {
-      "line": 58,
+      "line": 57,
       "column": 3
     }
   },
@@ -95,11 +95,11 @@
     "defaultMessage": "!!!Close Ferdi to system tray",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 59,
+      "line": 58,
       "column": 21
     },
     "end": {
-      "line": 62,
+      "line": 61,
       "column": 3
     }
   },
@@ -108,11 +108,11 @@
     "defaultMessage": "!!!Don't show message content in notifications",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 63,
+      "line": 62,
       "column": 24
     },
     "end": {
-      "line": 66,
+      "line": 65,
       "column": 3
     }
   },
@@ -121,11 +121,11 @@
     "defaultMessage": "!!!Notify TaskBar/Dock on new message",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 67,
+      "line": 66,
       "column": 26
     },
     "end": {
-      "line": 70,
+      "line": 69,
       "column": 3
     }
   },
@@ -134,11 +134,11 @@
     "defaultMessage": "!!!Navigation bar behaviour",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 71,
+      "line": 70,
       "column": 26
     },
     "end": {
-      "line": 74,
+      "line": 73,
       "column": 3
     }
   },
@@ -147,11 +147,11 @@
     "defaultMessage": "!!!Send telemetry data",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 75,
+      "line": 74,
       "column": 10
     },
     "end": {
-      "line": 78,
+      "line": 77,
       "column": 3
     }
   },
@@ -160,11 +160,11 @@
     "defaultMessage": "!!!Enable service hibernation",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 79,
+      "line": 78,
       "column": 13
     },
     "end": {
-      "line": 82,
+      "line": 81,
       "column": 3
     }
   },
@@ -173,11 +173,11 @@
     "defaultMessage": "!!!Keep services in hibernation on startup",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 83,
+      "line": 82,
       "column": 22
     },
     "end": {
-      "line": 86,
+      "line": 85,
       "column": 3
     }
   },
@@ -186,11 +186,11 @@
     "defaultMessage": "!!!Hibernation strategy",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 87,
+      "line": 86,
       "column": 23
     },
     "end": {
-      "line": 90,
+      "line": 89,
       "column": 3
     }
   },
@@ -199,11 +199,11 @@
     "defaultMessage": "!!!Todo Server",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 91,
+      "line": 90,
       "column": 24
     },
     "end": {
-      "line": 94,
+      "line": 93,
       "column": 3
     }
   },
@@ -212,11 +212,11 @@
     "defaultMessage": "!!!Custom TodoServer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 95,
+      "line": 94,
       "column": 20
     },
     "end": {
-      "line": 98,
+      "line": 97,
       "column": 3
     }
   },
@@ -225,11 +225,11 @@
     "defaultMessage": "!!!Enable Password Lock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 99,
+      "line": 98,
       "column": 14
     },
     "end": {
-      "line": 102,
+      "line": 101,
       "column": 3
     }
   },
@@ -238,11 +238,11 @@
     "defaultMessage": "!!!Password",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 103,
+      "line": 102,
       "column": 16
     },
     "end": {
-      "line": 106,
+      "line": 105,
       "column": 3
     }
   },
@@ -251,11 +251,11 @@
     "defaultMessage": "!!!Allow using Touch ID to unlock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 107,
+      "line": 106,
       "column": 22
     },
     "end": {
-      "line": 110,
+      "line": 109,
       "column": 3
     }
   },
@@ -264,11 +264,11 @@
     "defaultMessage": "!!!Lock after inactivity",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 111,
+      "line": 110,
       "column": 18
     },
     "end": {
-      "line": 114,
+      "line": 113,
       "column": 3
     }
   },
@@ -277,11 +277,11 @@
     "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 115,
+      "line": 114,
       "column": 23
     },
     "end": {
-      "line": 118,
+      "line": 117,
       "column": 3
     }
   },
@@ -290,11 +290,11 @@
     "defaultMessage": "!!!From",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 119,
+      "line": 118,
       "column": 21
     },
     "end": {
-      "line": 122,
+      "line": 121,
       "column": 3
     }
   },
@@ -303,11 +303,11 @@
     "defaultMessage": "!!!To",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 123,
+      "line": 122,
       "column": 19
     },
     "end": {
-      "line": 126,
+      "line": 125,
       "column": 3
     }
   },
@@ -316,11 +316,11 @@
     "defaultMessage": "!!!Language",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 127,
+      "line": 126,
       "column": 12
     },
     "end": {
-      "line": 130,
+      "line": 129,
       "column": 3
     }
   },
@@ -329,11 +329,11 @@
     "defaultMessage": "!!!Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 131,
+      "line": 130,
       "column": 12
     },
     "end": {
-      "line": 134,
+      "line": 133,
       "column": 3
     }
   },
@@ -342,11 +342,11 @@
     "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 135,
+      "line": 134,
       "column": 21
     },
     "end": {
-      "line": 138,
+      "line": 137,
       "column": 3
     }
   },
@@ -355,11 +355,11 @@
     "defaultMessage": "!!!Enable universal Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 139,
+      "line": 138,
       "column": 21
     },
     "end": {
-      "line": 142,
+      "line": 141,
       "column": 3
     }
   },
@@ -368,11 +368,11 @@
     "defaultMessage": "!!!Sidebar width",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 143,
+      "line": 142,
       "column": 22
     },
     "end": {
-      "line": 146,
+      "line": 145,
       "column": 3
     }
   },
@@ -381,11 +381,11 @@
     "defaultMessage": "!!!Service icon size",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 147,
+      "line": 146,
       "column": 12
     },
     "end": {
-      "line": 150,
+      "line": 149,
       "column": 3
     }
   },
@@ -394,11 +394,11 @@
     "defaultMessage": "!!!Use vertical style",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 151,
+      "line": 150,
       "column": 20
     },
     "end": {
-      "line": 154,
+      "line": 153,
       "column": 3
     }
   },
@@ -407,11 +407,11 @@
     "defaultMessage": "!!!Always show workspace drawer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 155,
+      "line": 154,
       "column": 24
     },
     "end": {
-      "line": 158,
+      "line": 157,
       "column": 3
     }
   },
@@ -420,11 +420,11 @@
     "defaultMessage": "!!!Accent color",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 159,
+      "line": 158,
       "column": 15
     },
     "end": {
-      "line": 162,
+      "line": 161,
       "column": 3
     }
   },
@@ -433,11 +433,11 @@
     "defaultMessage": "!!!Display disabled services tabs",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 163,
+      "line": 162,
       "column": 24
     },
     "end": {
-      "line": 166,
+      "line": 165,
       "column": 3
     }
   },
@@ -446,11 +446,11 @@
     "defaultMessage": "!!!Show unread message badge when notifications are disabled",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 167,
+      "line": 166,
       "column": 29
     },
     "end": {
-      "line": 170,
+      "line": 169,
       "column": 3
     }
   },
@@ -459,11 +459,11 @@
     "defaultMessage": "!!!Show draggable area on window",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 171,
+      "line": 170,
       "column": 16
     },
     "end": {
-      "line": 174,
+      "line": 173,
       "column": 3
     }
   },
@@ -472,11 +472,11 @@
     "defaultMessage": "!!!Enable spell checking",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 175,
+      "line": 174,
       "column": 23
     },
     "end": {
-      "line": 178,
+      "line": 177,
       "column": 3
     }
   },
@@ -485,11 +485,11 @@
     "defaultMessage": "!!!Enable GPU Acceleration",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 179,
+      "line": 178,
       "column": 25
     },
     "end": {
-      "line": 182,
+      "line": 181,
       "column": 3
     }
   },
@@ -498,11 +498,11 @@
     "defaultMessage": "!!!Include beta versions",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 183,
+      "line": 182,
       "column": 8
     },
     "end": {
-      "line": 186,
+      "line": 185,
       "column": 3
     }
   },
@@ -511,11 +511,11 @@
     "defaultMessage": "!!!Enable updates",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 187,
+      "line": 186,
       "column": 20
     },
     "end": {
-      "line": 190,
+      "line": 189,
       "column": 3
     }
   },
@@ -524,11 +524,11 @@
     "defaultMessage": "!!!Enable Franz Todos",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 191,
+      "line": 190,
       "column": 15
     },
     "end": {
-      "line": 194,
+      "line": 193,
       "column": 3
     }
   },
@@ -537,11 +537,11 @@
     "defaultMessage": "!!!Keep all workspaces loaded",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 195,
+      "line": 194,
       "column": 27
     },
     "end": {
-      "line": 198,
+      "line": 197,
       "column": 3
     }
   }


### PR DESCRIPTION
…ctron

### Description
Removing ProcessManager

### Motivation and Context
Chromium/Electron no longer support these modules/APIs. Since we have moved to Electron 11 (and soon to 12 as well) - it was discussed in #1296 to go ahead and remove these.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally