### PR TITLE
Fix spellcheckerLanguage array/string confusion

### DIFF
--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -268,7 +268,7 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
         showMessageBadgeWhenMuted: settingsData.showMessageBadgeWhenMuted,
         showDragArea: settingsData.showDragArea,
         enableSpellchecking: settingsData.enableSpellchecking,
-        spellcheckerLanguage: JSON.stringify(settingsData.spellcheckerLanguage),
+        spellcheckerLanguage: settingsData.spellcheckerLanguage,
         beta: settingsData.beta, // we need this info in the main process as well
         automaticUpdates: settingsData.automaticUpdates, // we need this info in the main process as well
         locale: settingsData.locale, // we need this info in the main process as well

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -128,17 +128,7 @@ class RecipeController {
   }
 
   @computed get spellcheckerLanguage() {
-    let selected;
-    const langs = this.settings.service.spellcheckerLanguage || this.settings.app.spellcheckerLanguage;
-    if (typeof langs === 'string' && langs.substr(0, 1) === '[') {
-      // Value is JSON encoded
-      selected = JSON.parse(langs);
-    } else if (typeof langs === 'object') {
-      selected = langs;
-    } else {
-      selected = [langs];
-    }
-
+    const selected = this.settings.service.spellcheckerLanguage || this.settings.app.spellcheckerLanguage;
     return selected;
   }
 


### PR DESCRIPTION
The `service.spellcheckerLanguage` and `app.spellcheckerLanguage` settings used to be arrays stored as a string with `JSON.stringify`, but sinze Ferdi 5.6.0, they are single locale strings. While we should eventually restore support for multiple spellchecking languages, in the meantime, there were several places were we wrongly treated the settings as arrays, which caused errors.

1. In `EditSettingsScreen`, we called `JSON.stringify` on the string. This caused an increasing number of escape sequences to be added to the string ("leaning toothpick syndrome"), making `settings.json` extremely large (it was 17M on my machine) and making the settings screen extremely slow to open.
2. In `webview/spellchecker.js`, `switchDict` assumes that its argument is a string, but we were passing an array to it from `webview/recipe.js`. This caused the spellchecker language update to fail, ignoring any language setting by the user.

Regarding the langauge selection, `webview/spellchecker.js` is still a bit spotty, because it hardcodes a German locale as the ultimate fallback. We should instead restore multiple spellchecking language support in the future.

There's still some slowness for me on the settings screen (with 10 services added), but that is probably some "event storm" type phenomenon in mobx, and is not caused by any absurdly large escaped locale string. I'll investigate that further, but this current PR seems to fix most of the settings screen slowness for me.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally