### PR TITLE
Highlight selected service correctly in Quick Switcher

### DIFF
--- a/src/features/quickSwitch/Component.js
+++ b/src/features/quickSwitch/Component.js
@@ -137,12 +137,17 @@ export default @injectSheet(styles) @inject('stores', 'actions') @observer class
       services = this.props.stores.services.allDisplayed;
       services = services.filter(service => service.name.toLowerCase().includes(this.state.search.toLowerCase()));
     } else {
+      // Add the currently active service first
+      const currentService = this.props.stores.services.active;
+      if (currentService) {
+        services.push(currentService);
+      }
+
       // Add last used services to services array
       for (const service of this.props.stores.services.lastUsedServices) {
-        if (this.props.stores.services.one(service)) {
-          services.push(
-            this.props.stores.services.one(service),
-          );
+        const tempService = this.props.stores.services.one(service);
+        if (tempService && !services.includes(tempService)) {
+          services.push(tempService);
         }
       }
 
@@ -164,6 +169,7 @@ export default @injectSheet(styles) @inject('stores', 'actions') @observer class
 
     // Reset and close modal
     this.setState({
+      selected: 0,
       search: '',
     });
     this.close();
@@ -188,7 +194,6 @@ export default @injectSheet(styles) @inject('stores', 'actions') @observer class
       if (serviceElement) {
         serviceElement.scrollIntoViewIfNeeded(false);
       }
-
 
       return {
         selected: newSelected,


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
Fixing the highlighted service in Quick Switcher

### Motivation and Context
Using the quick switcher, the list of services that had been navigated without / before the QS was intuitivily ordered by last-used. But, the highlighted service became out of sync if the Cmd+<number> shortcut was used bypassing the QS. This has now been fixed to be consistent always.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally