### PR TITLE
Added and documented cache setting for travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
     - os: osx
       if: branch IN (nightly, release)
       osx_image: xcode12
+      env:
+        - ELECTRON_CACHE=$HOME/.cache/electron
+        - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
 
 language: node_js
 node_js:
@@ -25,7 +28,11 @@ branches:
     - develop
     - release
     - nightly
-cache: npm
+cache:
+  directories:
+    - node_modules
+    - $HOME/.cache/electron
+    - $HOME/.cache/electron-builder
 
 before_install:
   - git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -33,20 +33,36 @@
 - [Ferdi](#ferdi)
     - [Table of contents](#table-of-contents)
     - [What is Ferdi?](#what-is-ferdi)
-    - [Features](#features)
+  - [Features](#features)
     - [What does Ferdi look like?](#what-does-ferdi-look-like)
   - [Download Ferdi](#download-ferdi)
+    - [Or use Chocolatey (Windows only)](#or-use-chocolatey-windows-only)
     - [Or use homebrew (macOS only)](#or-use-homebrew-macos-only)
     - [Or use AUR (Arch Linux)](#or-use-aur-arch-linux)
   - [What makes Ferdi different from Franz?](#what-makes-ferdi-different-from-franz)
+    - [Removes unproductive paywalls and other other interruptions](#removes-unproductive-paywalls-and-other-other-interruptions)
+    - [Adds features to increase your productivity](#adds-features-to-increase-your-productivity)
+    - [Adds features to improve your privacy](#adds-features-to-improve-your-privacy)
+    - [Adds features to improve your experience using Ferdi](#adds-features-to-improve-your-experience-using-ferdi)
+    - [Removed bugs](#removed-bugs)
+    - [Adds new platforms](#adds-new-platforms)
+    - [Adds internal changes](#adds-internal-changes)
   - [Development](#development)
     - [Install OS dependencies](#install-os-dependencies)
+      - [Node.js](#nodejs)
+      - [Git](#git)
+      - [Debian/Ubuntu](#debianubuntu)
+      - [Fedora](#fedora)
+      - [Windows](#windows)
     - [Clone repository with submodule](#clone-repository-with-submodule)
+    - [Local caching of dependencies](#local-caching-of-dependencies)
     - [Install dependencies](#install-dependencies)
     - [Fix native modules to match current electron node version](#fix-native-modules-to-match-current-electron-node-version)
+    - [Package recipe repository](#package-recipe-repository)
     - [Start development app](#start-development-app)
     - [Packaging](#packaging)
     - [Release](#release)
+      - [Nightly releases](#nightly-releases)
   - [Contributors ✨](#contributors-)
   - [Backers via OpenCollective](#backers-via-opencollective)
   - [Sponsors via OpenCollective](#sponsors-via-opencollective)
@@ -248,6 +264,15 @@ $ git submodule update --init --recursive
 ```
 
 It is important you execute the last command to get the required submodules (recipes, server).
+
+
+### Local caching of dependencies
+
+Set these env vars into your profile (or if you use [direnv](https://direnv.net/), you can manage them via the respective `.envrc` file)
+```bash
+export ELECTRON_CACHE=$HOME/.cache/electron
+export ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
+```
 
 ### Install dependencies
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,8 @@ skip_branch_with_pr: true
 cache:
   - '%APPDATA%\npm-cache'
   - node_modules
+  - '%USERPROFILE%\.electron'
+  - '%USERPROFILE%\.electron-builder'
 
 image: Visual Studio 2019
 


### PR DESCRIPTION
…local developer machine.

### Description
Cache settings for `electron` and `electron-builder`.

### Motivation and Context
local run of `npm run build` in a clean folder results in the following timings:
BEFORE: 8m 27s
AFTER: 6m26s

This is an almost 25% reduction in time - and the only difference is the usage of pre-downloaded / cached zips for electron.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally