### PR TITLE
Trying to fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
             - rpm
     - os: osx
       if: branch IN (nightly, release)
-      osx_image: xcode12
+      osx_image: xcode12.2
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder


### PR DESCRIPTION
### Description
Building of native modules in travis seems to break with "unsupported architecture". Trying to bump up the xcode version to see if it fixes the issue.

### Motivation and Context

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally