### PR TITLE
Turning on electron-builder cache for Linux builds as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
             - libxss-dev
             - libxkbfile-dev
             - rpm
+      env:
+        - ELECTRON_CACHE=$HOME/.cache/electron
+        - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
     - os: osx
       if: branch IN (nightly, release)
       osx_image: xcode12.2


### PR DESCRIPTION
### Description
In a previous PR, caching of electron-builder input assets has been done. This was missed for the linux builds - now this PR will enable this.

### Motivation and Context
Decreased build / packaging time.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally