### PR TITLE
Run complete PR builds for osx and linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
     - os: osx
-      if: branch IN (nightly, release)
       osx_image: xcode12.2
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
@@ -63,23 +62,19 @@ install:
   - travis_retry npm install node-sass -g || travis_terminate 1
 before_script:
   - npm run lint && npm run test || travis_terminate 1
-  - echo $pwd
-  - chown -R `whoami` .
-  - rm -rfv ./build ./out
 script:
   - |
+    echo "Building for branch: $TRAVIS_BRANCH"
     if [ $TRAVIS_BRANCH == "release" ]; then
-      echo "Building for release..."
       travis_retry travis_wait 100 npm run build -- --publish always -c.publish.provider=github -c.publish.owner=getferdi -c.publish.repo=ferdi -c.mac.identity=null || travis_terminate 1
-    fi
-  - |
-    if [ $TRAVIS_BRANCH == "nightly" ]; then
+    elif [ $TRAVIS_BRANCH == "nightly" ]; then
       git commit -am "Apply linter fixes [skip ci]"
       npm version prerelease --preid=nightly -m "%s and trigger AppVeyor nightly build [skip travisci]" || travis_terminate 1
-      echo "Building for nightly..."
       travis_retry travis_wait 100 npm run build -- --publish always -c.publish.provider=github -c.publish.owner=getferdi -c.publish.repo=nightlies || travis_terminate 1
       if [ $TRAVIS_OS_NAME == "osx" ]; then
         git remote add nightly https://${GH_TOKEN}@github.com/getferdi/ferdi.git > /dev/null 2>&1
         git push -qu nightly HEAD:nightly >/dev/null 2>&1
       fi
+    else
+      travis_retry travis_wait 100 npm run build || travis_terminate 1
     fi


### PR DESCRIPTION
### Description
Removed limitations for only running the complete `npm run build` for the `nightly` or `release` branch.

### Motivation and Context
This will ensure that any new PRs also run all the steps in the build - and we don't discover issues of building the native components AFTER they have been merged into the `develop` branch.

### Screenshots

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally