### PR TITLE
User agent as a user-preference

### DIFF
--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -380,6 +380,9 @@ export default @observer class EditServiceForm extends Component {
                       </p>
                     </>
                   )}
+                  <div className="user-agent">
+                    <Input field={form.$('userAgentPref')} />
+                  </div>
                   <Toggle field={form.$('isDarkModeEnabled')} />
                   {form.$('isDarkModeEnabled').value
                     && (

--- a/src/containers/settings/EditServiceScreen.js
+++ b/src/containers/settings/EditServiceScreen.js
@@ -101,6 +101,10 @@ const messages = defineMessages({
     id: 'settings.service.form.proxy.password',
     defaultMessage: '!!!Password',
   },
+  userAgentPref: {
+    id: 'settings.service.form.userAgentPref',
+    defaultMessage: '!!!User Agent',
+  },
 });
 
 export default @inject('stores', 'actions') @observer class EditServiceScreen extends Component {
@@ -161,6 +165,11 @@ export default @inject('stores', 'actions') @observer class EditServiceScreen ex
           label: intl.formatMessage(messages.name),
           placeholder: intl.formatMessage(messages.name),
           value: service.id ? service.name : recipe.name,
+        },
+        userAgentPref: {
+          label: intl.formatMessage(messages.userAgentPref),
+          placeholder: intl.formatMessage(messages.userAgentPref),
+          value: service.id ? service.userAgentPref : '',
         },
         isEnabled: {
           label: intl.formatMessage(messages.enableService),

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -4892,6 +4892,19 @@
           "column": 17,
           "line": 100
         }
+      },
+      {
+        "defaultMessage": "!!!User Agent",
+        "end": {
+          "column": 3,
+          "line": 107
+        },
+        "file": "src/containers/settings/EditServiceScreen.js",
+        "id": "settings.service.form.userAgentPref",
+        "start": {
+          "column": 17,
+          "line": 104
+        }
       }
     ],
     "path": "src/containers/settings/EditServiceScreen.json"

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -427,6 +427,7 @@
   "settings.service.form.tabOnPremise": "Self hosted ⭐️",
   "settings.service.form.team": "Team",
   "settings.service.form.useHostedService": "Use the hosted {name} service.",
+  "settings.service.form.userAgentPref": "User Agent",
   "settings.service.form.yourServices": "Your services",
   "settings.services.deletedInfo": "Service has been deleted",
   "settings.services.discoverServices": "Discover services",

--- a/src/i18n/messages/src/containers/settings/EditServiceScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditServiceScreen.json
@@ -245,5 +245,18 @@
       "line": 103,
       "column": 3
     }
+  },
+  {
+    "id": "settings.service.form.userAgentPref",
+    "defaultMessage": "!!!User Agent",
+    "file": "src/containers/settings/EditServiceScreen.js",
+    "start": {
+      "line": 104,
+      "column": 17
+    },
+    "end": {
+      "line": 107,
+      "column": 3
+    }
   }
 ]

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -94,6 +94,8 @@ export default class Service {
 
   @observable chromelessUserAgent = false;
 
+  @observable userAgentPref = '';
+
   constructor(data, recipe) {
     if (!data) {
       console.error('Service config not valid');
@@ -232,6 +234,10 @@ export default class Service {
   }
 
   @computed get userAgent() {
+    if (this.userAgentPref !== '') {
+      return this.userAgentPref;
+    }
+
     let ua = userAgent(this.chromelessUserAgent);
     if (typeof this.recipe.overrideUserAgent === 'function') {
       ua = this.recipe.overrideUserAgent();

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -216,7 +216,7 @@
 
     &::-webkit-scrollbar-thumb:window-inactive { background: none; }
     .service-flex-grid { display: flex; }
-    .service-name { flex: 1px; }
+    .service-name,.user-agent { flex: 1px; }
 
     .service-icon {
       float: right;
@@ -312,7 +312,7 @@
 
   .settings__delete-button { right: 0; }
   .settings__open-recipe-file-button {
-    cursor:pointer; 
+    cursor:pointer;
     margin-right: 10px;
   }
   .settings__open-recipe-file-container {


### PR DESCRIPTION
### Description
Ability for the user to specify a `user-agent` string as a service-specific preference.

### Motivation and Context
As being discussed in #1239 - but, **this is more of a POC to shake out what this direction might solve/uncover.**

### Screenshots
Please note the `Git branch`:
<img width="275" alt="Screen Shot 2021-05-10 at 11 53 19 AM" src="https://user-images.githubusercontent.com/69629/117615915-086d9500-b188-11eb-8d93-98c50b6711ec.png">

User Preferences screen:
<img width="631" alt="Screen Shot 2021-05-10 at 11 54 00 AM" src="https://user-images.githubusercontent.com/69629/117615962-19b6a180-b188-11eb-8d64-0eaaf97b0a87.png">

Service Developer tools showing the user-agent being sent on the network request:
<img width="805" alt="Screen Shot 2021-05-10 at 11 56 57 AM" src="https://user-images.githubusercontent.com/69629/117615978-220edc80-b188-11eb-91ac-ad2811d26700.png">


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally