### PR TITLE
Skip travis and appveyor *PR* builds for crowdin PRs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,5 +78,10 @@ script:
         git push -qu nightly HEAD:nightly >/dev/null 2>&1
       fi
     else
-      travis_retry travis_wait 100 npm run build || travis_terminate 1
+      if [[ $TRAVIS_COMMIT_MESSAGE =~ "New translations" ]]; then
+        echo "Skipping travis build"
+        travis_terminate 0
+      else
+        travis_retry travis_wait 100 npm run build || travis_terminate 1
+      fi
     fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,9 @@ for:
       - develop
   build_script:
     - appveyor-retry npm run build
+  skip_commits:
+    files:
+      - src/i18n/**/*.json
 -
   branches:
     only:


### PR DESCRIPTION
### Description

### Motivation and Context
No need to run the full build (`npm run build`) for these kind of builds - if they are part of the PR commit.

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally