### PR TITLE
Fixing issue with icons being garbled due to misconfiguration of gulp

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -24,7 +24,7 @@ dotenv.config();
 
 const uglify = composer(terser, console);
 
-const isDevBuild = ((process.env.NODE_ENV || 'development').trim().toLowerCase() === 'development');
+const isDevBuild = process.env.NODE_ENV === 'development';
 
 const getTargetEnv = isDevBuild ? 'development' : 'production';
 


### PR DESCRIPTION
env var.

### Description
All icons in the settings view were garbled. This PR fixes the same. Probably caused due to a missing env var that was incorrectly initialized.

### Motivation and Context
Fixing icons in settings view.

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally