### PR TITLE
Alternative shortcut for service switch (fix #850)

### DIFF
--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -7314,962 +7314,962 @@
         "defaultMessage": "!!!Edit",
         "end": {
           "column": 3,
-          "line": 25
+          "line": 27
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit",
         "start": {
           "column": 8,
-          "line": 22
+          "line": 24
         }
       },
       {
         "defaultMessage": "!!!Undo",
         "end": {
           "column": 3,
-          "line": 29
+          "line": 31
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.undo",
         "start": {
           "column": 8,
-          "line": 26
+          "line": 28
         }
       },
       {
         "defaultMessage": "!!!Redo",
         "end": {
           "column": 3,
-          "line": 33
+          "line": 35
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.redo",
         "start": {
           "column": 8,
-          "line": 30
+          "line": 32
         }
       },
       {
         "defaultMessage": "!!!Cut",
         "end": {
           "column": 3,
-          "line": 37
+          "line": 39
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.cut",
         "start": {
           "column": 7,
-          "line": 34
+          "line": 36
         }
       },
       {
         "defaultMessage": "!!!Copy",
         "end": {
           "column": 3,
-          "line": 41
+          "line": 43
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.copy",
         "start": {
           "column": 8,
-          "line": 38
+          "line": 40
         }
       },
       {
         "defaultMessage": "!!!Paste",
         "end": {
           "column": 3,
-          "line": 45
+          "line": 47
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.paste",
         "start": {
           "column": 9,
-          "line": 42
+          "line": 44
         }
       },
       {
         "defaultMessage": "!!!Paste And Match Style",
         "end": {
           "column": 3,
-          "line": 49
+          "line": 51
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.pasteAndMatchStyle",
         "start": {
           "column": 22,
-          "line": 46
+          "line": 48
         }
       },
       {
         "defaultMessage": "!!!Delete",
         "end": {
           "column": 3,
-          "line": 53
+          "line": 55
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.delete",
         "start": {
           "column": 10,
-          "line": 50
+          "line": 52
         }
       },
       {
         "defaultMessage": "!!!Select All",
         "end": {
           "column": 3,
-          "line": 57
+          "line": 59
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.selectAll",
         "start": {
           "column": 13,
-          "line": 54
+          "line": 56
         }
       },
       {
         "defaultMessage": "!!!Find in Page",
         "end": {
           "column": 3,
-          "line": 61
+          "line": 63
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.findInPage",
         "start": {
           "column": 14,
-          "line": 58
+          "line": 60
         }
       },
       {
         "defaultMessage": "!!!Speech",
         "end": {
           "column": 3,
-          "line": 65
+          "line": 67
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.speech",
         "start": {
           "column": 10,
-          "line": 62
+          "line": 64
         }
       },
       {
         "defaultMessage": "!!!Start Speaking",
         "end": {
           "column": 3,
-          "line": 69
+          "line": 71
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.startSpeaking",
         "start": {
           "column": 17,
-          "line": 66
+          "line": 68
         }
       },
       {
         "defaultMessage": "!!!Stop Speaking",
         "end": {
           "column": 3,
-          "line": 73
+          "line": 75
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.stopSpeaking",
         "start": {
           "column": 16,
-          "line": 70
+          "line": 72
         }
       },
       {
         "defaultMessage": "!!!Start Dictation",
         "end": {
           "column": 3,
-          "line": 77
+          "line": 79
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.startDictation",
         "start": {
           "column": 18,
-          "line": 74
+          "line": 76
         }
       },
       {
         "defaultMessage": "!!!Emoji & Symbols",
         "end": {
           "column": 3,
-          "line": 81
+          "line": 83
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.emojiSymbols",
         "start": {
           "column": 16,
-          "line": 78
+          "line": 80
         }
       },
       {
         "defaultMessage": "!!!Open Quick Switch",
         "end": {
           "column": 3,
-          "line": 85
+          "line": 87
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.openQuickSwitch",
         "start": {
           "column": 19,
-          "line": 82
+          "line": 84
         }
       },
       {
         "defaultMessage": "!!!Back",
         "end": {
           "column": 3,
-          "line": 89
+          "line": 91
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.back",
         "start": {
           "column": 8,
-          "line": 86
+          "line": 88
         }
       },
       {
         "defaultMessage": "!!!Forward",
         "end": {
           "column": 3,
-          "line": 93
+          "line": 95
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.forward",
         "start": {
           "column": 11,
-          "line": 90
+          "line": 92
         }
       },
       {
         "defaultMessage": "!!!Actual Size",
         "end": {
           "column": 3,
-          "line": 97
+          "line": 99
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.resetZoom",
         "start": {
           "column": 13,
-          "line": 94
+          "line": 96
         }
       },
       {
         "defaultMessage": "!!!Zoom In",
         "end": {
           "column": 3,
-          "line": 101
+          "line": 103
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.zoomIn",
         "start": {
           "column": 10,
-          "line": 98
+          "line": 100
         }
       },
       {
         "defaultMessage": "!!!Zoom Out",
         "end": {
           "column": 3,
-          "line": 105
+          "line": 107
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.zoomOut",
         "start": {
           "column": 11,
-          "line": 102
+          "line": 104
         }
       },
       {
         "defaultMessage": "!!!Enter Full Screen",
         "end": {
           "column": 3,
-          "line": 109
+          "line": 111
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.enterFullScreen",
         "start": {
           "column": 19,
-          "line": 106
+          "line": 108
         }
       },
       {
         "defaultMessage": "!!!Exit Full Screen",
         "end": {
           "column": 3,
-          "line": 113
+          "line": 115
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.exitFullScreen",
         "start": {
           "column": 18,
-          "line": 110
+          "line": 112
         }
       },
       {
         "defaultMessage": "!!!Toggle Full Screen",
         "end": {
           "column": 3,
-          "line": 117
+          "line": 119
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleFullScreen",
         "start": {
           "column": 20,
-          "line": 114
+          "line": 116
         }
       },
       {
         "defaultMessage": "!!!Toggle Dark Mode",
         "end": {
           "column": 3,
-          "line": 121
+          "line": 123
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleDarkMode",
         "start": {
           "column": 18,
-          "line": 118
+          "line": 120
         }
       },
       {
         "defaultMessage": "!!!Toggle Developer Tools",
         "end": {
           "column": 3,
-          "line": 125
+          "line": 127
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleDevTools",
         "start": {
           "column": 18,
-          "line": 122
+          "line": 124
         }
       },
       {
         "defaultMessage": "!!!Toggle Todos Developer Tools",
         "end": {
           "column": 3,
-          "line": 129
+          "line": 131
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleTodosDevTools",
         "start": {
           "column": 23,
-          "line": 126
+          "line": 128
         }
       },
       {
         "defaultMessage": "!!!Toggle Service Developer Tools",
         "end": {
           "column": 3,
-          "line": 133
+          "line": 135
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleServiceDevTools",
         "start": {
           "column": 25,
-          "line": 130
+          "line": 132
         }
       },
       {
         "defaultMessage": "!!!Reload Service",
         "end": {
           "column": 3,
-          "line": 137
+          "line": 139
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.reloadService",
         "start": {
           "column": 17,
-          "line": 134
+          "line": 136
         }
       },
       {
         "defaultMessage": "!!!Reload Ferdi",
         "end": {
           "column": 3,
-          "line": 141
+          "line": 143
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.reloadFranz",
         "start": {
           "column": 15,
-          "line": 138
+          "line": 140
         }
       },
       {
         "defaultMessage": "!!!Lock Ferdi",
         "end": {
           "column": 3,
-          "line": 145
+          "line": 147
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.lockFerdi",
         "start": {
           "column": 13,
-          "line": 142
+          "line": 144
         }
       },
       {
         "defaultMessage": "!!!Reload ToDos",
         "end": {
           "column": 3,
-          "line": 149
+          "line": 151
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.reloadTodos",
         "start": {
           "column": 15,
-          "line": 146
+          "line": 148
         }
       },
       {
         "defaultMessage": "!!!Minimize",
         "end": {
           "column": 3,
-          "line": 153
+          "line": 155
         },
         "file": "src/lib/Menu.js",
         "id": "menu.window.minimize",
         "start": {
           "column": 12,
-          "line": 150
+          "line": 152
         }
       },
       {
         "defaultMessage": "!!!Close",
         "end": {
           "column": 3,
-          "line": 157
+          "line": 159
         },
         "file": "src/lib/Menu.js",
         "id": "menu.window.close",
         "start": {
           "column": 9,
-          "line": 154
+          "line": 156
         }
       },
       {
         "defaultMessage": "!!!Learn More",
         "end": {
           "column": 3,
-          "line": 161
+          "line": 163
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.learnMore",
         "start": {
           "column": 13,
-          "line": 158
+          "line": 160
         }
       },
       {
         "defaultMessage": "!!!Changelog",
         "end": {
           "column": 3,
-          "line": 165
+          "line": 167
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.changelog",
         "start": {
           "column": 13,
-          "line": 162
+          "line": 164
         }
       },
       {
         "defaultMessage": "!!!Support",
         "end": {
           "column": 3,
-          "line": 169
+          "line": 171
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.support",
         "start": {
           "column": 11,
-          "line": 166
+          "line": 168
         }
       },
       {
         "defaultMessage": "!!!Copy Debug Information",
         "end": {
           "column": 3,
-          "line": 173
+          "line": 175
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.debugInfo",
         "start": {
           "column": 13,
-          "line": 170
+          "line": 172
         }
       },
       {
         "defaultMessage": "!!!Publish Debug Information",
         "end": {
           "column": 3,
-          "line": 177
+          "line": 179
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.publishDebugInfo",
         "start": {
           "column": 20,
-          "line": 174
+          "line": 176
         }
       },
       {
         "defaultMessage": "!!!Ferdi Debug Information",
         "end": {
           "column": 3,
-          "line": 181
+          "line": 183
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.debugInfoCopiedHeadline",
         "start": {
           "column": 27,
-          "line": 178
+          "line": 180
         }
       },
       {
         "defaultMessage": "!!!Your Debug Information has been copied to your clipboard.",
         "end": {
           "column": 3,
-          "line": 185
+          "line": 187
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.debugInfoCopiedBody",
         "start": {
           "column": 23,
-          "line": 182
+          "line": 184
         }
       },
       {
         "defaultMessage": "!!!Unlock with Touch ID",
         "end": {
           "column": 3,
-          "line": 189
+          "line": 191
         },
         "file": "src/lib/Menu.js",
         "id": "locked.touchId",
         "start": {
           "column": 11,
-          "line": 186
+          "line": 188
         }
       },
       {
         "defaultMessage": "!!!unlock via Touch ID",
         "end": {
           "column": 3,
-          "line": 193
+          "line": 195
         },
         "file": "src/lib/Menu.js",
         "id": "locked.touchIdPrompt",
         "start": {
           "column": 17,
-          "line": 190
+          "line": 192
         }
       },
       {
         "defaultMessage": "!!!Terms of Service",
         "end": {
           "column": 3,
-          "line": 197
+          "line": 199
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.tos",
         "start": {
           "column": 7,
-          "line": 194
+          "line": 196
         }
       },
       {
         "defaultMessage": "!!!Privacy Statement",
         "end": {
           "column": 3,
-          "line": 201
+          "line": 203
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.privacy",
         "start": {
           "column": 11,
-          "line": 198
+          "line": 200
         }
       },
       {
         "defaultMessage": "!!!File",
         "end": {
           "column": 3,
-          "line": 205
+          "line": 207
         },
         "file": "src/lib/Menu.js",
         "id": "menu.file",
         "start": {
           "column": 8,
-          "line": 202
+          "line": 204
         }
       },
       {
         "defaultMessage": "!!!View",
         "end": {
           "column": 3,
-          "line": 209
+          "line": 211
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view",
         "start": {
           "column": 8,
-          "line": 206
+          "line": 208
         }
       },
       {
         "defaultMessage": "!!!Services",
         "end": {
           "column": 3,
-          "line": 213
+          "line": 215
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services",
         "start": {
           "column": 12,
-          "line": 210
+          "line": 212
         }
       },
       {
         "defaultMessage": "!!!Window",
         "end": {
           "column": 3,
-          "line": 217
+          "line": 219
         },
         "file": "src/lib/Menu.js",
         "id": "menu.window",
         "start": {
           "column": 10,
-          "line": 214
+          "line": 216
         }
       },
       {
         "defaultMessage": "!!!Help",
         "end": {
           "column": 3,
-          "line": 221
+          "line": 223
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help",
         "start": {
           "column": 8,
-          "line": 218
+          "line": 220
         }
       },
       {
         "defaultMessage": "!!!About Ferdi",
         "end": {
           "column": 3,
-          "line": 225
+          "line": 227
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.about",
         "start": {
           "column": 9,
-          "line": 222
+          "line": 224
         }
       },
       {
         "defaultMessage": "!!!What's new?",
         "end": {
           "column": 3,
-          "line": 229
+          "line": 231
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.announcement",
         "start": {
           "column": 16,
-          "line": 226
+          "line": 228
         }
       },
       {
         "defaultMessage": "!!!Settings",
         "end": {
           "column": 3,
-          "line": 233
+          "line": 235
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.settings",
         "start": {
           "column": 12,
-          "line": 230
+          "line": 232
         }
       },
       {
         "defaultMessage": "!!!Check for updates",
         "end": {
           "column": 3,
-          "line": 237
+          "line": 239
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.checkForUpdates",
         "start": {
           "column": 19,
-          "line": 234
+          "line": 236
         }
       },
       {
         "defaultMessage": "!!!Hide",
         "end": {
           "column": 3,
-          "line": 241
+          "line": 243
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.hide",
         "start": {
           "column": 8,
-          "line": 238
+          "line": 240
         }
       },
       {
         "defaultMessage": "!!!Hide Others",
         "end": {
           "column": 3,
-          "line": 245
+          "line": 247
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.hideOthers",
         "start": {
           "column": 14,
-          "line": 242
+          "line": 244
         }
       },
       {
         "defaultMessage": "!!!Unhide",
         "end": {
           "column": 3,
-          "line": 249
+          "line": 251
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.unhide",
         "start": {
           "column": 10,
-          "line": 246
+          "line": 248
         }
       },
       {
         "defaultMessage": "!!!Auto-hide menu bar",
         "end": {
           "column": 3,
-          "line": 253
+          "line": 255
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.autohideMenuBar",
         "start": {
           "column": 19,
-          "line": 250
+          "line": 252
         }
       },
       {
         "defaultMessage": "!!!Quit",
         "end": {
           "column": 3,
-          "line": 257
+          "line": 259
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.quit",
         "start": {
           "column": 8,
-          "line": 254
+          "line": 256
         }
       },
       {
         "defaultMessage": "!!!Add New Service...",
         "end": {
           "column": 3,
-          "line": 261
+          "line": 263
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.addNewService",
         "start": {
           "column": 17,
-          "line": 258
+          "line": 260
         }
       },
       {
         "defaultMessage": "!!!Add New Workspace...",
         "end": {
           "column": 3,
-          "line": 265
+          "line": 267
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.addNewWorkspace",
         "start": {
           "column": 19,
-          "line": 262
+          "line": 264
         }
       },
       {
         "defaultMessage": "!!!Open workspace drawer",
         "end": {
           "column": 3,
-          "line": 269
+          "line": 271
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.openWorkspaceDrawer",
         "start": {
           "column": 23,
-          "line": 266
+          "line": 268
         }
       },
       {
         "defaultMessage": "!!!Close workspace drawer",
         "end": {
           "column": 3,
-          "line": 273
+          "line": 275
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.closeWorkspaceDrawer",
         "start": {
           "column": 24,
-          "line": 270
+          "line": 272
         }
       },
       {
         "defaultMessage": "!!!Activate next service...",
         "end": {
           "column": 3,
-          "line": 277
+          "line": 279
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.setNextServiceActive",
         "start": {
           "column": 23,
-          "line": 274
+          "line": 276
         }
       },
       {
         "defaultMessage": "!!!Activate previous service...",
         "end": {
           "column": 3,
-          "line": 281
+          "line": 283
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.activatePreviousService",
         "start": {
           "column": 27,
-          "line": 278
+          "line": 280
         }
       },
       {
         "defaultMessage": "!!!Disable notifications & audio",
         "end": {
           "column": 3,
-          "line": 285
+          "line": 287
         },
         "file": "src/lib/Menu.js",
         "id": "sidebar.muteApp",
         "start": {
           "column": 11,
-          "line": 282
+          "line": 284
         }
       },
       {
         "defaultMessage": "!!!Enable notifications & audio",
         "end": {
           "column": 3,
-          "line": 289
+          "line": 291
         },
         "file": "src/lib/Menu.js",
         "id": "sidebar.unmuteApp",
         "start": {
           "column": 13,
-          "line": 286
+          "line": 288
         }
       },
       {
         "defaultMessage": "!!!Workspaces",
         "end": {
           "column": 3,
-          "line": 293
+          "line": 295
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces",
         "start": {
           "column": 14,
-          "line": 290
+          "line": 292
         }
       },
       {
         "defaultMessage": "!!!Default",
         "end": {
           "column": 3,
-          "line": 297
+          "line": 299
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.defaultWorkspace",
         "start": {
           "column": 20,
-          "line": 294
+          "line": 296
         }
       },
       {
         "defaultMessage": "!!!Todos",
         "end": {
           "column": 3,
-          "line": 301
+          "line": 303
         },
         "file": "src/lib/Menu.js",
         "id": "menu.todos",
         "start": {
           "column": 9,
-          "line": 298
+          "line": 300
         }
       },
       {
         "defaultMessage": "!!!Open Todos drawer",
         "end": {
           "column": 3,
-          "line": 305
+          "line": 307
         },
         "file": "src/lib/Menu.js",
         "id": "menu.Todoss.openTodosDrawer",
         "start": {
           "column": 19,
-          "line": 302
+          "line": 304
         }
       },
       {
         "defaultMessage": "!!!Close Todos drawer",
         "end": {
           "column": 3,
-          "line": 309
+          "line": 311
         },
         "file": "src/lib/Menu.js",
         "id": "menu.Todoss.closeTodosDrawer",
         "start": {
           "column": 20,
-          "line": 306
+          "line": 308
         }
       },
       {
         "defaultMessage": "!!!Enable Todos",
         "end": {
           "column": 3,
-          "line": 313
+          "line": 315
         },
         "file": "src/lib/Menu.js",
         "id": "menu.todos.enableTodos",
         "start": {
           "column": 15,
-          "line": 310
+          "line": 312
         }
       },
       {
         "defaultMessage": "!!!Home",
         "end": {
           "column": 3,
-          "line": 317
+          "line": 319
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.goHome",
         "start": {
           "column": 17,
-          "line": 314
+          "line": 316
         }
       }
     ],

--- a/src/i18n/messages/src/lib/Menu.json
+++ b/src/i18n/messages/src/lib/Menu.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Edit",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 22,
+      "line": 24,
       "column": 8
     },
     "end": {
-      "line": 25,
+      "line": 27,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!Undo",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 26,
+      "line": 28,
       "column": 8
     },
     "end": {
-      "line": 29,
+      "line": 31,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Redo",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 30,
+      "line": 32,
       "column": 8
     },
     "end": {
-      "line": 33,
+      "line": 35,
       "column": 3
     }
   },
@@ -43,11 +43,11 @@
     "defaultMessage": "!!!Cut",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 34,
+      "line": 36,
       "column": 7
     },
     "end": {
-      "line": 37,
+      "line": 39,
       "column": 3
     }
   },
@@ -56,11 +56,11 @@
     "defaultMessage": "!!!Copy",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 38,
+      "line": 40,
       "column": 8
     },
     "end": {
-      "line": 41,
+      "line": 43,
       "column": 3
     }
   },
@@ -69,11 +69,11 @@
     "defaultMessage": "!!!Paste",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 42,
+      "line": 44,
       "column": 9
     },
     "end": {
-      "line": 45,
+      "line": 47,
       "column": 3
     }
   },
@@ -82,11 +82,11 @@
     "defaultMessage": "!!!Paste And Match Style",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 46,
+      "line": 48,
       "column": 22
     },
     "end": {
-      "line": 49,
+      "line": 51,
       "column": 3
     }
   },
@@ -95,11 +95,11 @@
     "defaultMessage": "!!!Delete",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 50,
+      "line": 52,
       "column": 10
     },
     "end": {
-      "line": 53,
+      "line": 55,
       "column": 3
     }
   },
@@ -108,11 +108,11 @@
     "defaultMessage": "!!!Select All",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 54,
+      "line": 56,
       "column": 13
     },
     "end": {
-      "line": 57,
+      "line": 59,
       "column": 3
     }
   },
@@ -121,11 +121,11 @@
     "defaultMessage": "!!!Find in Page",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 58,
+      "line": 60,
       "column": 14
     },
     "end": {
-      "line": 61,
+      "line": 63,
       "column": 3
     }
   },
@@ -134,11 +134,11 @@
     "defaultMessage": "!!!Speech",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 62,
+      "line": 64,
       "column": 10
     },
     "end": {
-      "line": 65,
+      "line": 67,
       "column": 3
     }
   },
@@ -147,11 +147,11 @@
     "defaultMessage": "!!!Start Speaking",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 66,
+      "line": 68,
       "column": 17
     },
     "end": {
-      "line": 69,
+      "line": 71,
       "column": 3
     }
   },
@@ -160,11 +160,11 @@
     "defaultMessage": "!!!Stop Speaking",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 70,
+      "line": 72,
       "column": 16
     },
     "end": {
-      "line": 73,
+      "line": 75,
       "column": 3
     }
   },
@@ -173,11 +173,11 @@
     "defaultMessage": "!!!Start Dictation",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 74,
+      "line": 76,
       "column": 18
     },
     "end": {
-      "line": 77,
+      "line": 79,
       "column": 3
     }
   },
@@ -186,11 +186,11 @@
     "defaultMessage": "!!!Emoji & Symbols",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 78,
+      "line": 80,
       "column": 16
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 3
     }
   },
@@ -199,11 +199,11 @@
     "defaultMessage": "!!!Open Quick Switch",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 82,
+      "line": 84,
       "column": 19
     },
     "end": {
-      "line": 85,
+      "line": 87,
       "column": 3
     }
   },
@@ -212,11 +212,11 @@
     "defaultMessage": "!!!Back",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 86,
+      "line": 88,
       "column": 8
     },
     "end": {
-      "line": 89,
+      "line": 91,
       "column": 3
     }
   },
@@ -225,11 +225,11 @@
     "defaultMessage": "!!!Forward",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 90,
+      "line": 92,
       "column": 11
     },
     "end": {
-      "line": 93,
+      "line": 95,
       "column": 3
     }
   },
@@ -238,11 +238,11 @@
     "defaultMessage": "!!!Actual Size",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 94,
+      "line": 96,
       "column": 13
     },
     "end": {
-      "line": 97,
+      "line": 99,
       "column": 3
     }
   },
@@ -251,11 +251,11 @@
     "defaultMessage": "!!!Zoom In",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 98,
+      "line": 100,
       "column": 10
     },
     "end": {
-      "line": 101,
+      "line": 103,
       "column": 3
     }
   },
@@ -264,11 +264,11 @@
     "defaultMessage": "!!!Zoom Out",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 102,
+      "line": 104,
       "column": 11
     },
     "end": {
-      "line": 105,
+      "line": 107,
       "column": 3
     }
   },
@@ -277,11 +277,11 @@
     "defaultMessage": "!!!Enter Full Screen",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 106,
+      "line": 108,
       "column": 19
     },
     "end": {
-      "line": 109,
+      "line": 111,
       "column": 3
     }
   },
@@ -290,11 +290,11 @@
     "defaultMessage": "!!!Exit Full Screen",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 110,
+      "line": 112,
       "column": 18
     },
     "end": {
-      "line": 113,
+      "line": 115,
       "column": 3
     }
   },
@@ -303,11 +303,11 @@
     "defaultMessage": "!!!Toggle Full Screen",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 114,
+      "line": 116,
       "column": 20
     },
     "end": {
-      "line": 117,
+      "line": 119,
       "column": 3
     }
   },
@@ -316,11 +316,11 @@
     "defaultMessage": "!!!Toggle Dark Mode",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 118,
+      "line": 120,
       "column": 18
     },
     "end": {
-      "line": 121,
+      "line": 123,
       "column": 3
     }
   },
@@ -329,11 +329,11 @@
     "defaultMessage": "!!!Toggle Developer Tools",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 122,
+      "line": 124,
       "column": 18
     },
     "end": {
-      "line": 125,
+      "line": 127,
       "column": 3
     }
   },
@@ -342,11 +342,11 @@
     "defaultMessage": "!!!Toggle Todos Developer Tools",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 126,
+      "line": 128,
       "column": 23
     },
     "end": {
-      "line": 129,
+      "line": 131,
       "column": 3
     }
   },
@@ -355,11 +355,11 @@
     "defaultMessage": "!!!Toggle Service Developer Tools",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 130,
+      "line": 132,
       "column": 25
     },
     "end": {
-      "line": 133,
+      "line": 135,
       "column": 3
     }
   },
@@ -368,11 +368,11 @@
     "defaultMessage": "!!!Reload Service",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 134,
+      "line": 136,
       "column": 17
     },
     "end": {
-      "line": 137,
+      "line": 139,
       "column": 3
     }
   },
@@ -381,11 +381,11 @@
     "defaultMessage": "!!!Reload Ferdi",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 138,
+      "line": 140,
       "column": 15
     },
     "end": {
-      "line": 141,
+      "line": 143,
       "column": 3
     }
   },
@@ -394,11 +394,11 @@
     "defaultMessage": "!!!Lock Ferdi",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 142,
+      "line": 144,
       "column": 13
     },
     "end": {
-      "line": 145,
+      "line": 147,
       "column": 3
     }
   },
@@ -407,11 +407,11 @@
     "defaultMessage": "!!!Reload ToDos",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 146,
+      "line": 148,
       "column": 15
     },
     "end": {
-      "line": 149,
+      "line": 151,
       "column": 3
     }
   },
@@ -420,11 +420,11 @@
     "defaultMessage": "!!!Minimize",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 150,
+      "line": 152,
       "column": 12
     },
     "end": {
-      "line": 153,
+      "line": 155,
       "column": 3
     }
   },
@@ -433,11 +433,11 @@
     "defaultMessage": "!!!Close",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 154,
+      "line": 156,
       "column": 9
     },
     "end": {
-      "line": 157,
+      "line": 159,
       "column": 3
     }
   },
@@ -446,11 +446,11 @@
     "defaultMessage": "!!!Learn More",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 158,
+      "line": 160,
       "column": 13
     },
     "end": {
-      "line": 161,
+      "line": 163,
       "column": 3
     }
   },
@@ -459,11 +459,11 @@
     "defaultMessage": "!!!Changelog",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 162,
+      "line": 164,
       "column": 13
     },
     "end": {
-      "line": 165,
+      "line": 167,
       "column": 3
     }
   },
@@ -472,11 +472,11 @@
     "defaultMessage": "!!!Support",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 166,
+      "line": 168,
       "column": 11
     },
     "end": {
-      "line": 169,
+      "line": 171,
       "column": 3
     }
   },
@@ -485,11 +485,11 @@
     "defaultMessage": "!!!Copy Debug Information",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 170,
+      "line": 172,
       "column": 13
     },
     "end": {
-      "line": 173,
+      "line": 175,
       "column": 3
     }
   },
@@ -498,11 +498,11 @@
     "defaultMessage": "!!!Publish Debug Information",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 174,
+      "line": 176,
       "column": 20
     },
     "end": {
-      "line": 177,
+      "line": 179,
       "column": 3
     }
   },
@@ -511,11 +511,11 @@
     "defaultMessage": "!!!Ferdi Debug Information",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 178,
+      "line": 180,
       "column": 27
     },
     "end": {
-      "line": 181,
+      "line": 183,
       "column": 3
     }
   },
@@ -524,11 +524,11 @@
     "defaultMessage": "!!!Your Debug Information has been copied to your clipboard.",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 182,
+      "line": 184,
       "column": 23
     },
     "end": {
-      "line": 185,
+      "line": 187,
       "column": 3
     }
   },
@@ -537,11 +537,11 @@
     "defaultMessage": "!!!Unlock with Touch ID",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 186,
+      "line": 188,
       "column": 11
     },
     "end": {
-      "line": 189,
+      "line": 191,
       "column": 3
     }
   },
@@ -550,11 +550,11 @@
     "defaultMessage": "!!!unlock via Touch ID",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 190,
+      "line": 192,
       "column": 17
     },
     "end": {
-      "line": 193,
+      "line": 195,
       "column": 3
     }
   },
@@ -563,11 +563,11 @@
     "defaultMessage": "!!!Terms of Service",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 194,
+      "line": 196,
       "column": 7
     },
     "end": {
-      "line": 197,
+      "line": 199,
       "column": 3
     }
   },
@@ -576,11 +576,11 @@
     "defaultMessage": "!!!Privacy Statement",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 198,
+      "line": 200,
       "column": 11
     },
     "end": {
-      "line": 201,
+      "line": 203,
       "column": 3
     }
   },
@@ -589,11 +589,11 @@
     "defaultMessage": "!!!File",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 202,
+      "line": 204,
       "column": 8
     },
     "end": {
-      "line": 205,
+      "line": 207,
       "column": 3
     }
   },
@@ -602,11 +602,11 @@
     "defaultMessage": "!!!View",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 206,
+      "line": 208,
       "column": 8
     },
     "end": {
-      "line": 209,
+      "line": 211,
       "column": 3
     }
   },
@@ -615,11 +615,11 @@
     "defaultMessage": "!!!Services",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 210,
+      "line": 212,
       "column": 12
     },
     "end": {
-      "line": 213,
+      "line": 215,
       "column": 3
     }
   },
@@ -628,11 +628,11 @@
     "defaultMessage": "!!!Window",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 214,
+      "line": 216,
       "column": 10
     },
     "end": {
-      "line": 217,
+      "line": 219,
       "column": 3
     }
   },
@@ -641,11 +641,11 @@
     "defaultMessage": "!!!Help",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 218,
+      "line": 220,
       "column": 8
     },
     "end": {
-      "line": 221,
+      "line": 223,
       "column": 3
     }
   },
@@ -654,11 +654,11 @@
     "defaultMessage": "!!!About Ferdi",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 222,
+      "line": 224,
       "column": 9
     },
     "end": {
-      "line": 225,
+      "line": 227,
       "column": 3
     }
   },
@@ -667,11 +667,11 @@
     "defaultMessage": "!!!What's new?",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 226,
+      "line": 228,
       "column": 16
     },
     "end": {
-      "line": 229,
+      "line": 231,
       "column": 3
     }
   },
@@ -680,11 +680,11 @@
     "defaultMessage": "!!!Settings",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 230,
+      "line": 232,
       "column": 12
     },
     "end": {
-      "line": 233,
+      "line": 235,
       "column": 3
     }
   },
@@ -693,11 +693,11 @@
     "defaultMessage": "!!!Check for updates",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 234,
+      "line": 236,
       "column": 19
     },
     "end": {
-      "line": 237,
+      "line": 239,
       "column": 3
     }
   },
@@ -706,11 +706,11 @@
     "defaultMessage": "!!!Hide",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 238,
+      "line": 240,
       "column": 8
     },
     "end": {
-      "line": 241,
+      "line": 243,
       "column": 3
     }
   },
@@ -719,11 +719,11 @@
     "defaultMessage": "!!!Hide Others",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 242,
+      "line": 244,
       "column": 14
     },
     "end": {
-      "line": 245,
+      "line": 247,
       "column": 3
     }
   },
@@ -732,11 +732,11 @@
     "defaultMessage": "!!!Unhide",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 246,
+      "line": 248,
       "column": 10
     },
     "end": {
-      "line": 249,
+      "line": 251,
       "column": 3
     }
   },
@@ -745,11 +745,11 @@
     "defaultMessage": "!!!Auto-hide menu bar",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 250,
+      "line": 252,
       "column": 19
     },
     "end": {
-      "line": 253,
+      "line": 255,
       "column": 3
     }
   },
@@ -758,11 +758,11 @@
     "defaultMessage": "!!!Quit",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 254,
+      "line": 256,
       "column": 8
     },
     "end": {
-      "line": 257,
+      "line": 259,
       "column": 3
     }
   },
@@ -771,11 +771,11 @@
     "defaultMessage": "!!!Add New Service...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 258,
+      "line": 260,
       "column": 17
     },
     "end": {
-      "line": 261,
+      "line": 263,
       "column": 3
     }
   },
@@ -784,11 +784,11 @@
     "defaultMessage": "!!!Add New Workspace...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 262,
+      "line": 264,
       "column": 19
     },
     "end": {
-      "line": 265,
+      "line": 267,
       "column": 3
     }
   },
@@ -797,11 +797,11 @@
     "defaultMessage": "!!!Open workspace drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 266,
+      "line": 268,
       "column": 23
     },
     "end": {
-      "line": 269,
+      "line": 271,
       "column": 3
     }
   },
@@ -810,11 +810,11 @@
     "defaultMessage": "!!!Close workspace drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 270,
+      "line": 272,
       "column": 24
     },
     "end": {
-      "line": 273,
+      "line": 275,
       "column": 3
     }
   },
@@ -823,11 +823,11 @@
     "defaultMessage": "!!!Activate next service...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 274,
+      "line": 276,
       "column": 23
     },
     "end": {
-      "line": 277,
+      "line": 279,
       "column": 3
     }
   },
@@ -836,11 +836,11 @@
     "defaultMessage": "!!!Activate previous service...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 278,
+      "line": 280,
       "column": 27
     },
     "end": {
-      "line": 281,
+      "line": 283,
       "column": 3
     }
   },
@@ -849,11 +849,11 @@
     "defaultMessage": "!!!Disable notifications & audio",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 282,
+      "line": 284,
       "column": 11
     },
     "end": {
-      "line": 285,
+      "line": 287,
       "column": 3
     }
   },
@@ -862,11 +862,11 @@
     "defaultMessage": "!!!Enable notifications & audio",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 286,
+      "line": 288,
       "column": 13
     },
     "end": {
-      "line": 289,
+      "line": 291,
       "column": 3
     }
   },
@@ -875,11 +875,11 @@
     "defaultMessage": "!!!Workspaces",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 290,
+      "line": 292,
       "column": 14
     },
     "end": {
-      "line": 293,
+      "line": 295,
       "column": 3
     }
   },
@@ -888,11 +888,11 @@
     "defaultMessage": "!!!Default",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 294,
+      "line": 296,
       "column": 20
     },
     "end": {
-      "line": 297,
+      "line": 299,
       "column": 3
     }
   },
@@ -901,11 +901,11 @@
     "defaultMessage": "!!!Todos",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 298,
+      "line": 300,
       "column": 9
     },
     "end": {
-      "line": 301,
+      "line": 303,
       "column": 3
     }
   },
@@ -914,11 +914,11 @@
     "defaultMessage": "!!!Open Todos drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 302,
+      "line": 304,
       "column": 19
     },
     "end": {
-      "line": 305,
+      "line": 307,
       "column": 3
     }
   },
@@ -927,11 +927,11 @@
     "defaultMessage": "!!!Close Todos drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 306,
+      "line": 308,
       "column": 20
     },
     "end": {
-      "line": 309,
+      "line": 311,
       "column": 3
     }
   },
@@ -940,11 +940,11 @@
     "defaultMessage": "!!!Enable Todos",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 310,
+      "line": 312,
       "column": 15
     },
     "end": {
-      "line": 313,
+      "line": 315,
       "column": 3
     }
   },
@@ -953,11 +953,11 @@
     "defaultMessage": "!!!Home",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 314,
+      "line": 316,
       "column": 17
     },
     "end": {
-      "line": 317,
+      "line": 319,
       "column": 3
     }
   }

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -1,7 +1,9 @@
 import { clipboard, remote, shell } from 'electron';
 import { autorun, observable } from 'mobx';
 import { defineMessages } from 'react-intl';
-import { cmdKey, ctrlKey, isMac } from '../environment';
+import {
+  cmdKey, ctrlKey, isLinux, isMac,
+} from '../environment';
 import { announcementsStore } from '../features/announcements';
 import { announcementActions } from '../features/announcements/actions';
 import { todosStore } from '../features/todos';
@@ -1113,6 +1115,7 @@ export default class FranzMenu {
     const { user, services, settings } = this.stores;
     if (!user.isLoggedIn) return [];
     const menu = [];
+    const cmdAltShortcutsVisibile = !isLinux;
 
     menu.push({
       label: intl.formatMessage(menuItems.addNewService),
@@ -1124,12 +1127,24 @@ export default class FranzMenu {
       type: 'separator',
     }, {
       label: intl.formatMessage(menuItems.activateNextService),
+      accelerator: `${cmdKey}+tab`,
+      click: () => this.actions.service.setActiveNext(),
+      visible: !cmdAltShortcutsVisibile,
+    }, {
+      label: intl.formatMessage(menuItems.activateNextService),
       accelerator: `${cmdKey}+alt+right`,
       click: () => this.actions.service.setActiveNext(),
+      visible: cmdAltShortcutsVisibile,
+    }, {
+      label: intl.formatMessage(menuItems.activatePreviousService),
+      accelerator: `${cmdKey}+shift+tab`,
+      click: () => this.actions.service.setActivePrev(),
+      visible: !cmdAltShortcutsVisibile,
     }, {
       label: intl.formatMessage(menuItems.activatePreviousService),
       accelerator: `${cmdKey}+alt+left`,
       click: () => this.actions.service.setActivePrev(),
+      visible: cmdAltShortcutsVisibile,
     }, {
       label: intl.formatMessage(
         settings.all.app.isAppMuted ? menuItems.unmuteApp : menuItems.muteApp,


### PR DESCRIPTION
On Linux, the default Ctrl+Alt+{Left, Right} shortcuts are not always
usable, because many desktop environments use them for workspace
switching.

We also set Ctrl+Tab and Ctrl+Shift+Tab as a service switching shortcut.
On Linux, these shortcuts are displayed in the menu, while on other
platforms, the older shortcuts remain displayed.
However, both shortcuts are enabled on all platforms, unless they are
eaten by the desktop environment.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally