### PR TITLE
Adding DuckDuckGo as an alternative search engine

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -331,10 +331,10 @@ export default @observer class EditSettingsForm extends Component {
                 {(isWindows || isMac) && (
                   <Toggle field={form.$('notifyTaskBarOnMessage')} />)}
                 <Select field={form.$('navigationBarBehaviour')} />
-                <Select field={form.$('searchEngine')} />
 
                 <Hr />
 
+                <Select field={form.$('searchEngine')} />
                 <Toggle field={form.$('sentry')} />
                 <p>{intl.formatMessage(messages.sentryInfo)}</p>
 

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -331,6 +331,7 @@ export default @observer class EditSettingsForm extends Component {
                 {(isWindows || isMac) && (
                   <Toggle field={form.$('notifyTaskBarOnMessage')} />)}
                 <Select field={form.$('navigationBarBehaviour')} />
+                <Select field={form.$('searchEngine')} />
 
                 <Hr />
 

--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,18 @@ export const NAVIGATION_BAR_BEHAVIOURS = {
   never: 'Never show navigation bar',
 };
 
+export const SEARCH_ENGINE_GOOGLE = 'google';
+export const SEARCH_ENGINE_DDG = 'duckDuckGo';
+export const SEARCH_ENGINE_NAMES = {
+  SEARCH_ENGINE_GOOGLE: 'Google',
+  SEARCH_ENGINE_DDG: 'Duck Duck Go',
+};
+
+export const SEARCH_ENGINE_URLS = {
+  SEARCH_ENGINE_GOOGLE: 'https://www.google.com/search?q=',
+  SEARCH_ENGINE_DDG: 'https://duckduckgo.com/?q=',
+};
+
 export const TODO_APPS = {
   'https://todoist.com/app': 'Todoist',
   'https://app.franztodos.com': 'Franz Todo',
@@ -135,6 +147,7 @@ export const DEFAULT_APP_SETTINGS = {
   sentry: false,
   nightly: false,
   navigationBarBehaviour: 'custom',
+  searchEngine: SEARCH_ENGINE_DDG,
   useVerticalStyle: false,
   alwaysShowWorkspaces: false,
 };

--- a/src/config.js
+++ b/src/config.js
@@ -55,13 +55,13 @@ export const NAVIGATION_BAR_BEHAVIOURS = {
 export const SEARCH_ENGINE_GOOGLE = 'google';
 export const SEARCH_ENGINE_DDG = 'duckDuckGo';
 export const SEARCH_ENGINE_NAMES = {
-  SEARCH_ENGINE_GOOGLE: 'Google',
-  SEARCH_ENGINE_DDG: 'Duck Duck Go',
+  [SEARCH_ENGINE_GOOGLE]: 'Google',
+  [SEARCH_ENGINE_DDG]: 'DuckDuckGo',
 };
 
 export const SEARCH_ENGINE_URLS = {
-  SEARCH_ENGINE_GOOGLE: 'https://www.google.com/search?q=',
-  SEARCH_ENGINE_DDG: 'https://duckduckgo.com/?q=',
+  [SEARCH_ENGINE_GOOGLE]: ({ searchTerm }) => `https://www.google.com/search?q=${searchTerm}`,
+  [SEARCH_ENGINE_DDG]: ({ searchTerm }) => `https://duckduckgo.com/?q=${searchTerm}`,
 };
 
 export const TODO_APPS = {

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -73,7 +73,7 @@ const messages = defineMessages({
   },
   searchEngine: {
     id: 'settings.app.form.searchEngine',
-    defaultMessage: '!!!Choose Search Engine',
+    defaultMessage: '!!!Search engine',
   },
   sentry: {
     id: 'settings.app.form.sentry',

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -10,7 +10,7 @@ import TodosStore from '../../features/todos/store';
 import Form from '../../lib/Form';
 import { APP_LOCALES, SPELLCHECKER_LOCALES } from '../../i18n/languages';
 import {
-  DEFAULT_APP_SETTINGS, HIBERNATION_STRATEGIES, SIDEBAR_WIDTH, ICON_SIZES, NAVIGATION_BAR_BEHAVIOURS, TODO_APPS,
+  DEFAULT_APP_SETTINGS, HIBERNATION_STRATEGIES, SIDEBAR_WIDTH, ICON_SIZES, NAVIGATION_BAR_BEHAVIOURS, SEARCH_ENGINE_NAMES, TODO_APPS,
 } from '../../config';
 import { config as spellcheckerConfig } from '../../features/spellchecker';
 
@@ -70,6 +70,10 @@ const messages = defineMessages({
   navigationBarBehaviour: {
     id: 'settings.app.form.navigationBarBehaviour',
     defaultMessage: '!!!Navigation bar behaviour',
+  },
+  searchEngine: {
+    id: 'settings.app.form.searchEngine',
+    defaultMessage: '!!!Choose Search Engine',
   },
   sentry: {
     id: 'settings.app.form.sentry',
@@ -241,6 +245,7 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
         privateNotifications: settingsData.privateNotifications,
         notifyTaskBarOnMessage: settingsData.notifyTaskBarOnMessage,
         navigationBarBehaviour: settingsData.navigationBarBehaviour,
+        searchEngine: settingsData.searchEngine,
         sentry: settingsData.sentry,
         hibernate: settingsData.hibernate,
         hibernateOnStartup: settingsData.hibernateOnStartup,
@@ -310,6 +315,11 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
 
     const navigationBarBehaviours = getSelectOptions({
       locales: NAVIGATION_BAR_BEHAVIOURS,
+      sort: false,
+    });
+
+    const searchEngines = getSelectOptions({
+      locales: SEARCH_ENGINE_NAMES,
       sort: false,
     });
 
@@ -395,6 +405,12 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           value: settings.all.app.navigationBarBehaviour,
           default: DEFAULT_APP_SETTINGS.navigationBarBehaviour,
           options: navigationBarBehaviours,
+        },
+        searchEngine: {
+          label: intl.formatMessage(messages.searchEngine),
+          value: settings.all.app.searchEngine,
+          default: DEFAULT_APP_SETTINGS.searchEngine,
+          options: searchEngines,
         },
         sentry: {
           label: intl.formatMessage(messages.sentry),

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -5029,406 +5029,419 @@
         }
       },
       {
-        "defaultMessage": "!!!Send telemetry data",
+        "defaultMessage": "!!!Choose Search Engine",
         "end": {
           "column": 3,
           "line": 77
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.searchEngine",
+        "start": {
+          "column": 16,
+          "line": 74
+        }
+      },
+      {
+        "defaultMessage": "!!!Send telemetry data",
+        "end": {
+          "column": 3,
+          "line": 81
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.sentry",
         "start": {
           "column": 10,
-          "line": 74
+          "line": 78
         }
       },
       {
         "defaultMessage": "!!!Enable service hibernation",
         "end": {
           "column": 3,
-          "line": 81
+          "line": 85
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.hibernate",
         "start": {
           "column": 13,
-          "line": 78
+          "line": 82
         }
       },
       {
         "defaultMessage": "!!!Keep services in hibernation on startup",
         "end": {
           "column": 3,
-          "line": 85
+          "line": 89
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.hibernateOnStartup",
         "start": {
           "column": 22,
-          "line": 82
+          "line": 86
         }
       },
       {
         "defaultMessage": "!!!Hibernation strategy",
         "end": {
           "column": 3,
-          "line": 89
+          "line": 93
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.hibernationStrategy",
         "start": {
           "column": 23,
-          "line": 86
+          "line": 90
         }
       },
       {
         "defaultMessage": "!!!Todo Server",
         "end": {
           "column": 3,
-          "line": 93
+          "line": 97
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.predefinedTodoServer",
         "start": {
           "column": 24,
-          "line": 90
+          "line": 94
         }
       },
       {
         "defaultMessage": "!!!Custom TodoServer",
         "end": {
           "column": 3,
-          "line": 97
+          "line": 101
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.customTodoServer",
         "start": {
           "column": 20,
-          "line": 94
+          "line": 98
         }
       },
       {
         "defaultMessage": "!!!Enable Password Lock",
         "end": {
           "column": 3,
-          "line": 101
+          "line": 105
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableLock",
         "start": {
           "column": 14,
-          "line": 98
+          "line": 102
         }
       },
       {
         "defaultMessage": "!!!Password",
         "end": {
           "column": 3,
-          "line": 105
+          "line": 109
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.lockPassword",
         "start": {
           "column": 16,
-          "line": 102
+          "line": 106
         }
       },
       {
         "defaultMessage": "!!!Allow using Touch ID to unlock",
         "end": {
           "column": 3,
-          "line": 109
+          "line": 113
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.useTouchIdToUnlock",
         "start": {
           "column": 22,
-          "line": 106
+          "line": 110
         }
       },
       {
         "defaultMessage": "!!!Lock after inactivity",
         "end": {
           "column": 3,
-          "line": 113
+          "line": 117
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.inactivityLock",
         "start": {
           "column": 18,
-          "line": 110
+          "line": 114
         }
       },
       {
         "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
         "end": {
           "column": 3,
-          "line": 117
+          "line": 121
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDEnabled",
         "start": {
           "column": 23,
-          "line": 114
+          "line": 118
         }
       },
       {
         "defaultMessage": "!!!From",
         "end": {
           "column": 3,
-          "line": 121
+          "line": 125
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDStart",
         "start": {
           "column": 21,
-          "line": 118
+          "line": 122
         }
       },
       {
         "defaultMessage": "!!!To",
         "end": {
           "column": 3,
-          "line": 125
+          "line": 129
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDEnd",
         "start": {
           "column": 19,
-          "line": 122
+          "line": 126
         }
       },
       {
         "defaultMessage": "!!!Language",
         "end": {
           "column": 3,
-          "line": 129
-        },
-        "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.language",
-        "start": {
-          "column": 12,
-          "line": 126
-        }
-      },
-      {
-        "defaultMessage": "!!!Dark Mode",
-        "end": {
-          "column": 3,
           "line": 133
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.darkMode",
+        "id": "settings.app.form.language",
         "start": {
           "column": 12,
           "line": 130
         }
       },
       {
-        "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
+        "defaultMessage": "!!!Dark Mode",
         "end": {
           "column": 3,
           "line": 137
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.adaptableDarkMode",
+        "id": "settings.app.form.darkMode",
         "start": {
-          "column": 21,
+          "column": 12,
           "line": 134
         }
       },
       {
-        "defaultMessage": "!!!Enable universal Dark Mode",
+        "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
         "end": {
           "column": 3,
           "line": 141
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.universalDarkMode",
+        "id": "settings.app.form.adaptableDarkMode",
         "start": {
           "column": 21,
           "line": 138
         }
       },
       {
-        "defaultMessage": "!!!Sidebar width",
+        "defaultMessage": "!!!Enable universal Dark Mode",
         "end": {
           "column": 3,
           "line": 145
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.universalDarkMode",
+        "start": {
+          "column": 21,
+          "line": 142
+        }
+      },
+      {
+        "defaultMessage": "!!!Sidebar width",
+        "end": {
+          "column": 3,
+          "line": 149
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.serviceRibbonWidth",
         "start": {
           "column": 22,
-          "line": 142
+          "line": 146
         }
       },
       {
         "defaultMessage": "!!!Service icon size",
         "end": {
           "column": 3,
-          "line": 149
+          "line": 153
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.iconSize",
         "start": {
           "column": 12,
-          "line": 146
+          "line": 150
         }
       },
       {
         "defaultMessage": "!!!Use vertical style",
         "end": {
           "column": 3,
-          "line": 153
+          "line": 157
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.useVerticalStyle",
         "start": {
           "column": 20,
-          "line": 150
+          "line": 154
         }
       },
       {
         "defaultMessage": "!!!Always show workspace drawer",
         "end": {
           "column": 3,
-          "line": 157
+          "line": 161
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.alwaysShowWorkspaces",
         "start": {
           "column": 24,
-          "line": 154
+          "line": 158
         }
       },
       {
         "defaultMessage": "!!!Accent color",
         "end": {
           "column": 3,
-          "line": 161
+          "line": 165
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.accentColor",
         "start": {
           "column": 15,
-          "line": 158
+          "line": 162
         }
       },
       {
         "defaultMessage": "!!!Display disabled services tabs",
         "end": {
           "column": 3,
-          "line": 165
+          "line": 169
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showDisabledServices",
         "start": {
           "column": 24,
-          "line": 162
+          "line": 166
         }
       },
       {
         "defaultMessage": "!!!Show unread message badge when notifications are disabled",
         "end": {
           "column": 3,
-          "line": 169
+          "line": 173
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showMessagesBadgesWhenMuted",
         "start": {
           "column": 29,
-          "line": 166
+          "line": 170
         }
       },
       {
         "defaultMessage": "!!!Show draggable area on window",
         "end": {
           "column": 3,
-          "line": 173
+          "line": 177
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showDragArea",
         "start": {
           "column": 16,
-          "line": 170
+          "line": 174
         }
       },
       {
         "defaultMessage": "!!!Enable spell checking",
         "end": {
           "column": 3,
-          "line": 177
+          "line": 181
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableSpellchecking",
         "start": {
           "column": 23,
-          "line": 174
+          "line": 178
         }
       },
       {
         "defaultMessage": "!!!Enable GPU Acceleration",
         "end": {
           "column": 3,
-          "line": 181
+          "line": 185
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableGPUAcceleration",
         "start": {
           "column": 25,
-          "line": 178
+          "line": 182
         }
       },
       {
         "defaultMessage": "!!!Include beta versions",
         "end": {
           "column": 3,
-          "line": 185
+          "line": 189
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.beta",
         "start": {
           "column": 8,
-          "line": 182
+          "line": 186
         }
       },
       {
         "defaultMessage": "!!!Enable updates",
         "end": {
           "column": 3,
-          "line": 189
+          "line": 193
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.automaticUpdates",
         "start": {
           "column": 20,
-          "line": 186
+          "line": 190
         }
       },
       {
         "defaultMessage": "!!!Enable Franz Todos",
         "end": {
           "column": 3,
-          "line": 193
+          "line": 197
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableTodos",
         "start": {
           "column": 15,
-          "line": 190
+          "line": 194
         }
       },
       {
         "defaultMessage": "!!!Keep all workspaces loaded",
         "end": {
           "column": 3,
-          "line": 197
+          "line": 201
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.keepAllWorkspacesLoaded",
         "start": {
           "column": 27,
-          "line": 194
+          "line": 198
         }
       }
     ],

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -5029,7 +5029,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Choose Search Engine",
+        "defaultMessage": "!!!Search engine",
         "end": {
           "column": 3,
           "line": 77

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -319,6 +319,7 @@
   "settings.app.form.scheduledDNDEnabled": "Enable scheduled Do-not-Disturb",
   "settings.app.form.scheduledDNDEnd": "To",
   "settings.app.form.scheduledDNDStart": "From",
+  "settings.app.form.searchEngine": "Choose Search Engine",
   "settings.app.form.sentry": "Send telemetry data",
   "settings.app.form.serviceRibbonWidth": "Sidebar width",
   "settings.app.form.showDisabledServices": "Display disabled services tabs",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -319,7 +319,7 @@
   "settings.app.form.scheduledDNDEnabled": "Enable scheduled Do-not-Disturb",
   "settings.app.form.scheduledDNDEnd": "To",
   "settings.app.form.scheduledDNDStart": "From",
-  "settings.app.form.searchEngine": "Choose Search Engine",
+  "settings.app.form.searchEngine": "Search engine",
   "settings.app.form.sentry": "Send telemetry data",
   "settings.app.form.serviceRibbonWidth": "Sidebar width",
   "settings.app.form.showDisabledServices": "Display disabled services tabs",

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -143,15 +143,28 @@
     }
   },
   {
+    "id": "settings.app.form.searchEngine",
+    "defaultMessage": "!!!Choose Search Engine",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 74,
+      "column": 16
+    },
+    "end": {
+      "line": 77,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.sentry",
     "defaultMessage": "!!!Send telemetry data",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 74,
+      "line": 78,
       "column": 10
     },
     "end": {
-      "line": 77,
+      "line": 81,
       "column": 3
     }
   },
@@ -160,11 +173,11 @@
     "defaultMessage": "!!!Enable service hibernation",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 78,
+      "line": 82,
       "column": 13
     },
     "end": {
-      "line": 81,
+      "line": 85,
       "column": 3
     }
   },
@@ -173,11 +186,11 @@
     "defaultMessage": "!!!Keep services in hibernation on startup",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 82,
+      "line": 86,
       "column": 22
     },
     "end": {
-      "line": 85,
+      "line": 89,
       "column": 3
     }
   },
@@ -186,11 +199,11 @@
     "defaultMessage": "!!!Hibernation strategy",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 86,
+      "line": 90,
       "column": 23
     },
     "end": {
-      "line": 89,
+      "line": 93,
       "column": 3
     }
   },
@@ -199,11 +212,11 @@
     "defaultMessage": "!!!Todo Server",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 90,
+      "line": 94,
       "column": 24
     },
     "end": {
-      "line": 93,
+      "line": 97,
       "column": 3
     }
   },
@@ -212,11 +225,11 @@
     "defaultMessage": "!!!Custom TodoServer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 94,
+      "line": 98,
       "column": 20
     },
     "end": {
-      "line": 97,
+      "line": 101,
       "column": 3
     }
   },
@@ -225,11 +238,11 @@
     "defaultMessage": "!!!Enable Password Lock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 98,
+      "line": 102,
       "column": 14
     },
     "end": {
-      "line": 101,
+      "line": 105,
       "column": 3
     }
   },
@@ -238,11 +251,11 @@
     "defaultMessage": "!!!Password",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 102,
+      "line": 106,
       "column": 16
     },
     "end": {
-      "line": 105,
+      "line": 109,
       "column": 3
     }
   },
@@ -251,11 +264,11 @@
     "defaultMessage": "!!!Allow using Touch ID to unlock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 106,
+      "line": 110,
       "column": 22
     },
     "end": {
-      "line": 109,
+      "line": 113,
       "column": 3
     }
   },
@@ -264,11 +277,11 @@
     "defaultMessage": "!!!Lock after inactivity",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 110,
+      "line": 114,
       "column": 18
     },
     "end": {
-      "line": 113,
+      "line": 117,
       "column": 3
     }
   },
@@ -277,11 +290,11 @@
     "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 114,
+      "line": 118,
       "column": 23
     },
     "end": {
-      "line": 117,
+      "line": 121,
       "column": 3
     }
   },
@@ -290,11 +303,11 @@
     "defaultMessage": "!!!From",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 118,
+      "line": 122,
       "column": 21
     },
     "end": {
-      "line": 121,
+      "line": 125,
       "column": 3
     }
   },
@@ -303,21 +316,8 @@
     "defaultMessage": "!!!To",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 122,
-      "column": 19
-    },
-    "end": {
-      "line": 125,
-      "column": 3
-    }
-  },
-  {
-    "id": "settings.app.form.language",
-    "defaultMessage": "!!!Language",
-    "file": "src/containers/settings/EditSettingsScreen.js",
-    "start": {
       "line": 126,
-      "column": 12
+      "column": 19
     },
     "end": {
       "line": 129,
@@ -325,8 +325,8 @@
     }
   },
   {
-    "id": "settings.app.form.darkMode",
-    "defaultMessage": "!!!Dark Mode",
+    "id": "settings.app.form.language",
+    "defaultMessage": "!!!Language",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 130,
@@ -338,12 +338,12 @@
     }
   },
   {
-    "id": "settings.app.form.adaptableDarkMode",
-    "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
+    "id": "settings.app.form.darkMode",
+    "defaultMessage": "!!!Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 134,
-      "column": 21
+      "column": 12
     },
     "end": {
       "line": 137,
@@ -351,8 +351,8 @@
     }
   },
   {
-    "id": "settings.app.form.universalDarkMode",
-    "defaultMessage": "!!!Enable universal Dark Mode",
+    "id": "settings.app.form.adaptableDarkMode",
+    "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 138,
@@ -364,15 +364,28 @@
     }
   },
   {
+    "id": "settings.app.form.universalDarkMode",
+    "defaultMessage": "!!!Enable universal Dark Mode",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 142,
+      "column": 21
+    },
+    "end": {
+      "line": 145,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.serviceRibbonWidth",
     "defaultMessage": "!!!Sidebar width",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 142,
+      "line": 146,
       "column": 22
     },
     "end": {
-      "line": 145,
+      "line": 149,
       "column": 3
     }
   },
@@ -381,11 +394,11 @@
     "defaultMessage": "!!!Service icon size",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 146,
+      "line": 150,
       "column": 12
     },
     "end": {
-      "line": 149,
+      "line": 153,
       "column": 3
     }
   },
@@ -394,11 +407,11 @@
     "defaultMessage": "!!!Use vertical style",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 150,
+      "line": 154,
       "column": 20
     },
     "end": {
-      "line": 153,
+      "line": 157,
       "column": 3
     }
   },
@@ -407,11 +420,11 @@
     "defaultMessage": "!!!Always show workspace drawer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 154,
+      "line": 158,
       "column": 24
     },
     "end": {
-      "line": 157,
+      "line": 161,
       "column": 3
     }
   },
@@ -420,11 +433,11 @@
     "defaultMessage": "!!!Accent color",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 158,
+      "line": 162,
       "column": 15
     },
     "end": {
-      "line": 161,
+      "line": 165,
       "column": 3
     }
   },
@@ -433,11 +446,11 @@
     "defaultMessage": "!!!Display disabled services tabs",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 162,
+      "line": 166,
       "column": 24
     },
     "end": {
-      "line": 165,
+      "line": 169,
       "column": 3
     }
   },
@@ -446,11 +459,11 @@
     "defaultMessage": "!!!Show unread message badge when notifications are disabled",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 166,
+      "line": 170,
       "column": 29
     },
     "end": {
-      "line": 169,
+      "line": 173,
       "column": 3
     }
   },
@@ -459,11 +472,11 @@
     "defaultMessage": "!!!Show draggable area on window",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 170,
+      "line": 174,
       "column": 16
     },
     "end": {
-      "line": 173,
+      "line": 177,
       "column": 3
     }
   },
@@ -472,11 +485,11 @@
     "defaultMessage": "!!!Enable spell checking",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 174,
+      "line": 178,
       "column": 23
     },
     "end": {
-      "line": 177,
+      "line": 181,
       "column": 3
     }
   },
@@ -485,11 +498,11 @@
     "defaultMessage": "!!!Enable GPU Acceleration",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 178,
+      "line": 182,
       "column": 25
     },
     "end": {
-      "line": 181,
+      "line": 185,
       "column": 3
     }
   },
@@ -498,11 +511,11 @@
     "defaultMessage": "!!!Include beta versions",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 182,
+      "line": 186,
       "column": 8
     },
     "end": {
-      "line": 185,
+      "line": 189,
       "column": 3
     }
   },
@@ -511,11 +524,11 @@
     "defaultMessage": "!!!Enable updates",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 186,
+      "line": 190,
       "column": 20
     },
     "end": {
-      "line": 189,
+      "line": 193,
       "column": 3
     }
   },
@@ -524,11 +537,11 @@
     "defaultMessage": "!!!Enable Franz Todos",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 190,
+      "line": 194,
       "column": 15
     },
     "end": {
-      "line": 193,
+      "line": 197,
       "column": 3
     }
   },
@@ -537,11 +550,11 @@
     "defaultMessage": "!!!Keep all workspaces loaded",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 194,
+      "line": 198,
       "column": 27
     },
     "end": {
-      "line": 197,
+      "line": 201,
       "column": 3
     }
   }

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -144,7 +144,7 @@
   },
   {
     "id": "settings.app.form.searchEngine",
-    "defaultMessage": "!!!Choose Search Engine",
+    "defaultMessage": "!!!Search engine",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 74,

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -130,6 +130,11 @@ export default class ServicesStore extends Store {
       () => this.stores.settings.app.universalDarkMode,
       () => this._shareSettingsWithServiceProcess(),
     );
+
+    reaction(
+      () => this.stores.settings.app.searchEngine,
+      () => this._shareSettingsWithServiceProcess(),
+    );
   }
 
   initialize() {

--- a/src/stores/SettingsStore.js
+++ b/src/stores/SettingsStore.js
@@ -3,7 +3,9 @@ import {
   action, computed, observable, reaction,
 } from 'mobx';
 import localStorage from 'mobx-localstorage';
-import { DEFAULT_APP_SETTINGS, FILE_SYSTEM_SETTINGS_TYPES, LOCAL_SERVER } from '../config';
+import {
+  DEFAULT_APP_SETTINGS, FILE_SYSTEM_SETTINGS_TYPES, LOCAL_SERVER, SEARCH_ENGINE_DDG,
+} from '../config';
 import { API } from '../environment';
 import { getLocale } from '../helpers/i18n-helpers';
 import { hash } from '../helpers/password-helpers';
@@ -300,6 +302,22 @@ export default class SettingsStore extends Store {
       });
 
       debug('Migrated updates settings');
+    }
+
+    if (!this.all.migration['5.6.0-beta.6-settings']) {
+      this.actions.settings.update({
+        type: 'app',
+        data: {
+          searchEngine: SEARCH_ENGINE_DDG,
+        },
+      });
+
+      this.actions.settings.update({
+        type: 'migration',
+        data: {
+          '5.6.0-beta.6-settings': true,
+        },
+      });
     }
   }
 }

--- a/src/webview/contextMenu.js
+++ b/src/webview/contextMenu.js
@@ -3,7 +3,7 @@ import ContextMenuBuilder from './contextMenuBuilder';
 
 const webContents = remote.getCurrentWebContents();
 
-export default async function setupContextMenu(isSpellcheckEnabled, getDefaultSpellcheckerLanguage, getSpellcheckerLanguage) {
+export default async function setupContextMenu(isSpellcheckEnabled, getDefaultSpellcheckerLanguage, getSpellcheckerLanguage, getSearchEngine) {
   const contextMenuBuilder = new ContextMenuBuilder(
     webContents,
   );
@@ -11,7 +11,7 @@ export default async function setupContextMenu(isSpellcheckEnabled, getDefaultSp
   webContents.on('context-menu', (e, props) => {
     // TODO?: e.preventDefault();
     contextMenuBuilder.showPopupMenu(
-      props,
+      { ...props, searchEngine: getSearchEngine() },
       isSpellcheckEnabled(),
       getDefaultSpellcheckerLanguage(),
       getSpellcheckerLanguage(),

--- a/src/webview/contextMenuBuilder.js
+++ b/src/webview/contextMenuBuilder.js
@@ -8,6 +8,8 @@
  */
 import { isMac } from '../environment';
 
+import { SEARCH_ENGINE_NAMES, SEARCH_ENGINE_URLS } from '../config';
+
 const {
   clipboard, nativeImage, remote, shell,
 } = require('electron');
@@ -27,7 +29,7 @@ const contextMenuStringTable = {
   cut: () => 'Cut',
   copy: () => 'Copy',
   paste: () => 'Paste',
-  searchGoogle: () => 'Search with Google',
+  searchWith: ({ searchEngine }) => `Search with ${searchEngine}`,
   openLinkUrl: () => 'Open Link',
   openLinkInFerdiUrl: () => 'Open Link in Ferdi',
   openInBrowser: () => 'Open in Browser',
@@ -286,9 +288,9 @@ module.exports = class ContextMenuBuilder {
     }
 
     const search = new MenuItem({
-      label: this.stringTable.searchGoogle(),
+      label: this.stringTable.searchWith({ searchEngine: SEARCH_ENGINE_NAMES[menuInfo.searchEngine] }),
       click: () => {
-        const url = `https://www.google.com/search?q=${encodeURIComponent(menuInfo.selectionText)}`;
+        const url = `${SEARCH_ENGINE_URLS[menuInfo.searchEngine]}${encodeURIComponent(menuInfo.selectionText)}`;
 
         shell.openExternal(url);
       },

--- a/src/webview/contextMenuBuilder.js
+++ b/src/webview/contextMenuBuilder.js
@@ -290,8 +290,7 @@ module.exports = class ContextMenuBuilder {
     const search = new MenuItem({
       label: this.stringTable.searchWith({ searchEngine: SEARCH_ENGINE_NAMES[menuInfo.searchEngine] }),
       click: () => {
-        const url = `${SEARCH_ENGINE_URLS[menuInfo.searchEngine]}${encodeURIComponent(menuInfo.selectionText)}`;
-
+        const url = SEARCH_ENGINE_URLS[menuInfo.searchEngine]({ searchTerm: encodeURIComponent(menuInfo.selectionText) });
         shell.openExternal(url);
       },
     });

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -152,6 +152,7 @@ class RecipeController {
       () => this.settings.app.enableSpellchecking,
       () => this.settings.app.spellcheckerLanguage,
       () => this.spellcheckerLanguage,
+      () => this.settings.app.searchEngine,
     );
 
     autorun(() => this.update());
@@ -230,6 +231,7 @@ class RecipeController {
     debug('System spellcheckerLanguage', this.settings.app.spellcheckerLanguage);
     debug('Service spellcheckerLanguage', this.settings.service.spellcheckerLanguage);
     debug('darkReaderSettigs', this.settings.service.darkReaderSettings);
+    debug('searchEngine', this.settings.app.searchEngine);
 
     if (this.userscript && this.userscript.internal_setSettings) {
       this.userscript.internal_setSettings(this.settings);


### PR DESCRIPTION
### Description
Provide a choice to the user with a different search engine (Duck Duck Go in this case).

### Motivation and Context
Allow the user a choice of search engines.

### Screenshots

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally