### PR TITLE
Separated privacy & security settings into its own tab in the preferences screen

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -396,6 +396,57 @@ export default @observer class EditSettingsForm extends Component {
                   </>
                 )}
 
+
+                <Hr />
+
+                <Toggle field={form.$('scheduledDNDEnabled')} />
+                {scheduledDNDEnabled && (
+                  <>
+                    <div style={{
+                      display: 'flex',
+                      justifyContent: 'center',
+                    }}
+                    >
+                      <div style={{
+                        padding: '0 1rem',
+                        width: '100%',
+                      }}
+                      >
+                        <Input
+                          placeholder="17:00"
+                          onChange={e => this.submit(e)}
+                          field={form.$('scheduledDNDStart')}
+                          type="time"
+                        />
+                      </div>
+                      <div style={{
+                        padding: '0 1rem',
+                        width: '100%',
+                      }}
+                      >
+                        <Input
+                          placeholder="09:00"
+                          onChange={e => this.submit(e)}
+                          field={form.$('scheduledDNDEnd')}
+                          type="time"
+                        />
+                      </div>
+                    </div>
+                    <p>
+                      { intl.formatMessage(messages.scheduledDNDTimeInfo) }
+                    </p>
+                  </>
+                )}
+                <p
+                  className="settings__message"
+                  style={{
+                    borderTop: 0, marginTop: 0, paddingTop: 0, marginBottom: '2rem',
+                  }}
+                >
+                  <span>
+                    { intl.formatMessage(messages.scheduledDNDInfo) }
+                  </span>
+                </p>
               </div>
             )}
 
@@ -505,57 +556,6 @@ export default @observer class EditSettingsForm extends Component {
                 >
                   <span>
                     { intl.formatMessage(messages.lockInfo) }
-                  </span>
-                </p>
-
-                <Hr />
-
-                <Toggle field={form.$('scheduledDNDEnabled')} />
-                {scheduledDNDEnabled && (
-                  <>
-                    <div style={{
-                      display: 'flex',
-                      justifyContent: 'center',
-                    }}
-                    >
-                      <div style={{
-                        padding: '0 1rem',
-                        width: '100%',
-                      }}
-                      >
-                        <Input
-                          placeholder="17:00"
-                          onChange={e => this.submit(e)}
-                          field={form.$('scheduledDNDStart')}
-                          type="time"
-                        />
-                      </div>
-                      <div style={{
-                        padding: '0 1rem',
-                        width: '100%',
-                      }}
-                      >
-                        <Input
-                          placeholder="09:00"
-                          onChange={e => this.submit(e)}
-                          field={form.$('scheduledDNDEnd')}
-                          type="time"
-                        />
-                      </div>
-                    </div>
-                    <p>
-                      { intl.formatMessage(messages.scheduledDNDTimeInfo) }
-                    </p>
-                  </>
-                )}
-                <p
-                  className="settings__message"
-                  style={{
-                    borderTop: 0, marginTop: 0, paddingTop: 0, marginBottom: '2rem',
-                  }}
-                >
-                  <span>
-                    { intl.formatMessage(messages.scheduledDNDInfo) }
                   </span>
                 </p>
               </div>

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -88,6 +88,10 @@ const messages = defineMessages({
     id: 'settings.app.accentColorInfo',
     defaultMessage: '!!!Write your accent color in a CSS-compatible format. (Default: {defaultAccentColor})',
   },
+  headlinePrivacy: {
+    id: 'settings.app.headlinePrivacy',
+    defaultMessage: '!!!Privacy',
+  },
   headlineAdvanced: {
     id: 'settings.app.headlineAdvanced',
     defaultMessage: '!!!Advanced',
@@ -291,6 +295,13 @@ export default @observer class EditSettingsForm extends Component {
                 {intl.formatMessage(messages.headlineAppearance)}
               </h2>
               <h2
+                id="privacy"
+                className={this.state.activeSetttingsTab === 'privacy' ? 'badge badge--primary' : 'badge'}
+                onClick={() => { this.setActiveSettingsTab('privacy'); }}
+              >
+                {intl.formatMessage(messages.headlinePrivacy)}
+              </h2>
+              <h2
                 id="language"
                 className={this.state.activeSetttingsTab === 'language' ? 'badge badge--primary' : 'badge'}
                 onClick={() => { this.setActiveSettingsTab('language'); }}
@@ -327,16 +338,7 @@ export default @observer class EditSettingsForm extends Component {
                 {isWindows && (
                   <Toggle field={form.$('closeToSystemTray')} />
                 )}
-                <Toggle field={form.$('privateNotifications')} />
-                {(isWindows || isMac) && (
-                  <Toggle field={form.$('notifyTaskBarOnMessage')} />)}
                 <Select field={form.$('navigationBarBehaviour')} />
-
-                <Hr />
-
-                <Select field={form.$('searchEngine')} />
-                <Toggle field={form.$('sentry')} />
-                <p>{intl.formatMessage(messages.sentryInfo)}</p>
 
                 <Hr />
 
@@ -393,6 +395,75 @@ export default @observer class EditSettingsForm extends Component {
                     )}
                   </>
                 )}
+
+              </div>
+            )}
+
+            {/* Appearance */}
+            { this.state.activeSetttingsTab === 'appearance' && (
+              <div>
+                <Toggle field={form.$('showDisabledServices')} />
+                <Toggle field={form.$('showMessageBadgeWhenMuted')} />
+
+                {isMac && <Toggle field={form.$('showDragArea')} />}
+
+                <Hr />
+
+                <Toggle field={form.$('adaptableDarkMode')} />
+                {!isAdaptableDarkModeEnabled && <Toggle field={form.$('darkMode')} />}
+                {(isDarkmodeEnabled || isAdaptableDarkModeEnabled) && (
+                <>
+                  <Toggle field={form.$('universalDarkMode')} />
+                  <p
+                    className="settings__message"
+                    style={{
+                      borderTop: 0, marginTop: 0, paddingTop: 0, marginBottom: '2rem',
+                    }}
+                  >
+                    <span>
+                      { intl.formatMessage(messages.universalDarkModeInfo) }
+                    </span>
+                  </p>
+                </>
+                )}
+
+                <Hr />
+
+                <Select field={form.$('serviceRibbonWidth')} />
+
+                <Toggle field={form.$('useVerticalStyle')} />
+
+                <Toggle field={form.$('alwaysShowWorkspaces')} />
+
+                <Hr />
+                <Select field={form.$('iconSize')} />
+
+                <Hr />
+
+                <Input
+                  placeholder="Accent Color"
+                  onChange={e => this.submit(e)}
+                  field={form.$('accentColor')}
+                />
+                <p>
+                  {intl.formatMessage(messages.accentColorInfo,
+                    { defaultAccentColor: DEFAULT_APP_SETTINGS.accentColor })}
+                </p>
+              </div>
+            )}
+
+            {/* Privacy */}
+            { this.state.activeSetttingsTab === 'privacy' && (
+              <div>
+                <Toggle field={form.$('privateNotifications')} />
+                {(isWindows || isMac) && (
+                  <Toggle field={form.$('notifyTaskBarOnMessage')} />)}
+
+                <Hr />
+
+                <Select field={form.$('searchEngine')} />
+                <Toggle field={form.$('sentry')} />
+                <p>{intl.formatMessage(messages.sentryInfo)}</p>
 
                 <Hr />
 
@@ -486,59 +557,6 @@ export default @observer class EditSettingsForm extends Component {
                   <span>
                     { intl.formatMessage(messages.scheduledDNDInfo) }
                   </span>
-                </p>
-              </div>
-            )}
-
-            {/* Appearance */}
-            { this.state.activeSetttingsTab === 'appearance' && (
-              <div>
-                <Toggle field={form.$('showDisabledServices')} />
-                <Toggle field={form.$('showMessageBadgeWhenMuted')} />
-
-                {isMac && <Toggle field={form.$('showDragArea')} />}
-
-                <Hr />
-
-                <Toggle field={form.$('adaptableDarkMode')} />
-                {!isAdaptableDarkModeEnabled && <Toggle field={form.$('darkMode')} />}
-                {(isDarkmodeEnabled || isAdaptableDarkModeEnabled) && (
-                <>
-                  <Toggle field={form.$('universalDarkMode')} />
-                  <p
-                    className="settings__message"
-                    style={{
-                      borderTop: 0, marginTop: 0, paddingTop: 0, marginBottom: '2rem',
-                    }}
-                  >
-                    <span>
-                      { intl.formatMessage(messages.universalDarkModeInfo) }
-                    </span>
-                  </p>
-                </>
-                )}
-
-                <Hr />
-
-                <Select field={form.$('serviceRibbonWidth')} />
-
-                <Toggle field={form.$('useVerticalStyle')} />
-
-                <Toggle field={form.$('alwaysShowWorkspaces')} />
-
-                <Hr />
-                <Select field={form.$('iconSize')} />
-
-                <Hr />
-
-                <Input
-                  placeholder="Accent Color"
-                  onChange={e => this.submit(e)}
-                  field={form.$('accentColor')}
-                />
-                <p>
-                  {intl.formatMessage(messages.accentColorInfo,
-                    { defaultAccentColor: DEFAULT_APP_SETTINGS.accentColor })}
                 </p>
               </div>
             )}

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -3446,198 +3446,211 @@
         }
       },
       {
-        "defaultMessage": "!!!Advanced",
+        "defaultMessage": "!!!Privacy",
         "end": {
           "column": 3,
           "line": 94
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
+        "id": "settings.app.headlinePrivacy",
+        "start": {
+          "column": 19,
+          "line": 91
+        }
+      },
+      {
+        "defaultMessage": "!!!Advanced",
+        "end": {
+          "column": 3,
+          "line": 98
+        },
+        "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.headlineAdvanced",
         "start": {
           "column": 20,
-          "line": 91
+          "line": 95
         }
       },
       {
         "defaultMessage": "!!!Help us to translate Ferdi into your language.",
         "end": {
           "column": 3,
-          "line": 98
+          "line": 102
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.translationHelp",
         "start": {
           "column": 19,
-          "line": 95
+          "line": 99
         }
       },
       {
         "defaultMessage": "!!!Ferdi uses your Mac's build-in spellchecker to check for typos. If you want to change the languages the spellchecker checks for, you can do so in your Mac's System Preferences.",
         "end": {
           "column": 3,
-          "line": 102
+          "line": 106
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.spellCheckerLanguageInfo",
         "start": {
           "column": 28,
-          "line": 99
+          "line": 103
         }
       },
       {
         "defaultMessage": "!!!Cache",
         "end": {
           "column": 3,
-          "line": 106
+          "line": 110
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.subheadlineCache",
         "start": {
           "column": 20,
-          "line": 103
+          "line": 107
         }
       },
       {
         "defaultMessage": "!!!Ferdi cache is currently using {size} of disk space.",
         "end": {
           "column": 3,
-          "line": 110
+          "line": 114
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.cacheInfo",
         "start": {
           "column": 13,
-          "line": 107
+          "line": 111
         }
       },
       {
         "defaultMessage": "!!!Couldn't clear all cache",
         "end": {
           "column": 3,
-          "line": 114
+          "line": 118
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.cacheNotCleared",
         "start": {
           "column": 19,
-          "line": 111
+          "line": 115
         }
       },
       {
         "defaultMessage": "!!!Clear cache",
         "end": {
           "column": 3,
-          "line": 118
+          "line": 122
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.buttonClearAllCache",
         "start": {
           "column": 23,
-          "line": 115
+          "line": 119
         }
       },
       {
         "defaultMessage": "!!!Check for updates",
         "end": {
           "column": 3,
-          "line": 122
+          "line": 126
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.buttonSearchForUpdate",
         "start": {
           "column": 25,
-          "line": 119
+          "line": 123
         }
       },
       {
         "defaultMessage": "!!!Restart & install update",
         "end": {
           "column": 3,
-          "line": 126
+          "line": 130
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.buttonInstallUpdate",
         "start": {
           "column": 23,
-          "line": 123
+          "line": 127
         }
       },
       {
         "defaultMessage": "!!!Is searching for update",
         "end": {
           "column": 3,
-          "line": 130
-        },
-        "file": "src/components/settings/settings/EditSettingsForm.js",
-        "id": "settings.app.updateStatusSearching",
-        "start": {
-          "column": 25,
-          "line": 127
-        }
-      },
-      {
-        "defaultMessage": "!!!Update available, downloading...",
-        "end": {
-          "column": 3,
           "line": 134
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
-        "id": "settings.app.updateStatusAvailable",
+        "id": "settings.app.updateStatusSearching",
         "start": {
           "column": 25,
           "line": 131
         }
       },
       {
-        "defaultMessage": "!!!You are using the latest version of Ferdi",
+        "defaultMessage": "!!!Update available, downloading...",
         "end": {
           "column": 3,
           "line": 138
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
+        "id": "settings.app.updateStatusAvailable",
+        "start": {
+          "column": 25,
+          "line": 135
+        }
+      },
+      {
+        "defaultMessage": "!!!You are using the latest version of Ferdi",
+        "end": {
+          "column": 3,
+          "line": 142
+        },
+        "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.updateStatusUpToDate",
         "start": {
           "column": 24,
-          "line": 135
+          "line": 139
         }
       },
       {
         "defaultMessage": "!!!Current version:",
         "end": {
           "column": 3,
-          "line": 142
+          "line": 146
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.currentVersion",
         "start": {
           "column": 18,
-          "line": 139
+          "line": 143
         }
       },
       {
         "defaultMessage": "!!!Changes require restart",
         "end": {
           "column": 3,
-          "line": 146
+          "line": 150
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.restartRequired",
         "start": {
           "column": 29,
-          "line": 143
+          "line": 147
         }
       },
       {
         "defaultMessage": "!!!Official translations are English & German. All other languages are community based translations.",
         "end": {
           "column": 3,
-          "line": 150
+          "line": 154
         },
         "file": "src/components/settings/settings/EditSettingsForm.js",
         "id": "settings.app.languageDisclaimer",
         "start": {
           "column": 22,
-          "line": 147
+          "line": 151
         }
       }
     ],

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -334,6 +334,7 @@
   "settings.app.headlineAppearance": "Appearance",
   "settings.app.headlineGeneral": "General",
   "settings.app.headlineLanguage": "Language",
+  "settings.app.headlinePrivacy": "Privacy",
   "settings.app.headlineUpdates": "Updates",
   "settings.app.hibernateInfo": "By default, Ferdi will keep all your services open and loaded in the background so they are ready when you want to use them. Service Hibernation will unload your services after a specified amount. This is useful to save RAM or keeping services from slowing down your computer.",
   "settings.app.inactivityLockInfo": "Minutes of inactivity, after which Ferdi should automatically lock. Use 0 to disable",

--- a/src/i18n/messages/src/components/settings/settings/EditSettingsForm.json
+++ b/src/i18n/messages/src/components/settings/settings/EditSettingsForm.json
@@ -208,15 +208,28 @@
     }
   },
   {
+    "id": "settings.app.headlinePrivacy",
+    "defaultMessage": "!!!Privacy",
+    "file": "src/components/settings/settings/EditSettingsForm.js",
+    "start": {
+      "line": 91,
+      "column": 19
+    },
+    "end": {
+      "line": 94,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.headlineAdvanced",
     "defaultMessage": "!!!Advanced",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 91,
+      "line": 95,
       "column": 20
     },
     "end": {
-      "line": 94,
+      "line": 98,
       "column": 3
     }
   },
@@ -225,11 +238,11 @@
     "defaultMessage": "!!!Help us to translate Ferdi into your language.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 95,
+      "line": 99,
       "column": 19
     },
     "end": {
-      "line": 98,
+      "line": 102,
       "column": 3
     }
   },
@@ -238,11 +251,11 @@
     "defaultMessage": "!!!Ferdi uses your Mac's build-in spellchecker to check for typos. If you want to change the languages the spellchecker checks for, you can do so in your Mac's System Preferences.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 99,
+      "line": 103,
       "column": 28
     },
     "end": {
-      "line": 102,
+      "line": 106,
       "column": 3
     }
   },
@@ -251,11 +264,11 @@
     "defaultMessage": "!!!Cache",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 103,
+      "line": 107,
       "column": 20
     },
     "end": {
-      "line": 106,
+      "line": 110,
       "column": 3
     }
   },
@@ -264,11 +277,11 @@
     "defaultMessage": "!!!Ferdi cache is currently using {size} of disk space.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 107,
+      "line": 111,
       "column": 13
     },
     "end": {
-      "line": 110,
+      "line": 114,
       "column": 3
     }
   },
@@ -277,11 +290,11 @@
     "defaultMessage": "!!!Couldn't clear all cache",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 111,
+      "line": 115,
       "column": 19
     },
     "end": {
-      "line": 114,
+      "line": 118,
       "column": 3
     }
   },
@@ -290,11 +303,11 @@
     "defaultMessage": "!!!Clear cache",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 115,
+      "line": 119,
       "column": 23
     },
     "end": {
-      "line": 118,
+      "line": 122,
       "column": 3
     }
   },
@@ -303,11 +316,11 @@
     "defaultMessage": "!!!Check for updates",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 119,
+      "line": 123,
       "column": 25
     },
     "end": {
-      "line": 122,
+      "line": 126,
       "column": 3
     }
   },
@@ -316,21 +329,8 @@
     "defaultMessage": "!!!Restart & install update",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 123,
-      "column": 23
-    },
-    "end": {
-      "line": 126,
-      "column": 3
-    }
-  },
-  {
-    "id": "settings.app.updateStatusSearching",
-    "defaultMessage": "!!!Is searching for update",
-    "file": "src/components/settings/settings/EditSettingsForm.js",
-    "start": {
       "line": 127,
-      "column": 25
+      "column": 23
     },
     "end": {
       "line": 130,
@@ -338,8 +338,8 @@
     }
   },
   {
-    "id": "settings.app.updateStatusAvailable",
-    "defaultMessage": "!!!Update available, downloading...",
+    "id": "settings.app.updateStatusSearching",
+    "defaultMessage": "!!!Is searching for update",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
       "line": 131,
@@ -351,15 +351,28 @@
     }
   },
   {
+    "id": "settings.app.updateStatusAvailable",
+    "defaultMessage": "!!!Update available, downloading...",
+    "file": "src/components/settings/settings/EditSettingsForm.js",
+    "start": {
+      "line": 135,
+      "column": 25
+    },
+    "end": {
+      "line": 138,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.updateStatusUpToDate",
     "defaultMessage": "!!!You are using the latest version of Ferdi",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 135,
+      "line": 139,
       "column": 24
     },
     "end": {
-      "line": 138,
+      "line": 142,
       "column": 3
     }
   },
@@ -368,11 +381,11 @@
     "defaultMessage": "!!!Current version:",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 139,
+      "line": 143,
       "column": 18
     },
     "end": {
-      "line": 142,
+      "line": 146,
       "column": 3
     }
   },
@@ -381,11 +394,11 @@
     "defaultMessage": "!!!Changes require restart",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 143,
+      "line": 147,
       "column": 29
     },
     "end": {
-      "line": 146,
+      "line": 150,
       "column": 3
     }
   },
@@ -394,11 +407,11 @@
     "defaultMessage": "!!!Official translations are English & German. All other languages are community based translations.",
     "file": "src/components/settings/settings/EditSettingsForm.js",
     "start": {
-      "line": 147,
+      "line": 151,
       "column": 22
     },
     "end": {
-      "line": 150,
+      "line": 154,
       "column": 3
     }
   }


### PR DESCRIPTION
### Description
Separated privacy & security settings into its own tab in the preferences screen

### Motivation and Context
With the latest code, the "General" tab in the Preferences screen was getting too lengthy - forcing the user to do vertical scrolling to see/manage the prefs.
<img width="662" alt="Screen Shot 2021-05-15 at 9 57 43 PM" src="https://user-images.githubusercontent.com/69629/118371552-b8009800-b5ca-11eb-8aa6-f9bfe038def3.png">
(notice the vertical scrollbar on the right)
And the continuation of the same screen is:
<img width="656" alt="Screen Shot 2021-05-15 at 9 58 05 PM" src="https://user-images.githubusercontent.com/69629/118371580-d6669380-b5ca-11eb-81f3-3da044f930cf.png">

Some of these prefs could be re-grouped into a "Privacy" tab, thus also reducing the need for vertical scrolling:
<img width="649" alt="Screen Shot 2021-05-15 at 10 01 52 PM" src="https://user-images.githubusercontent.com/69629/118371605-f302cb80-b5ca-11eb-8a84-c5178e93aa90.png">
(of course, there are still a couple of prefs that fall below the viewport)
and the "Privacy" tab shows like this:
<img width="663" alt="Screen Shot 2021-05-15 at 10 02 06 PM" src="https://user-images.githubusercontent.com/69629/118371630-1af22f00-b5cb-11eb-83a9-a1a4ed227860.png">


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally