### PR TITLE
Updated documentation with gDrive url as a stopgap measure of broken nightlies process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,14 +142,15 @@ The above will place all the built artifacts into the `/ferdi` folder within the
 If you want to copy them outside of the image, simply mount a volume into a different location, and copy all files from `/ferdi` into the mounted folder (`/ferdi-out` in the example command below).
 
 ```bash
-mkdir -p tmp-out
-docker run -v $PWD/tmp-out:/ferdi-out -it ferdi-package sh
+DATE=`date +"%Y-%b-%d-%H-%M"`
+mkdir -p ~/Downloads/$DATE
+docker run -e GIT_SHA=`git rev-parse --short HEAD` -v ~/Downloads/$DATE:/ferdi-out -it ferdi-package sh
 # inside the container:
-mv /ferdi/Ferdi-5.6.0-nightly.18.AppImage /ferdi-out/Ferdi-`date +%Y-%b-%d`.AppImage
-mv /ferdi/ferdi-5.6.0-nightly.18.tar.gz /ferdi-out/Ferdi-`date +%Y-%b-%d`.tar.gz
-mv /ferdi/ferdi-5.6.0-nightly.18.x86_64.rpm /ferdi-out/Ferdi-`date +%Y-%b-%d`.x86_64.rpm
-mv /ferdi/ferdi_5.6.0-nightly.18_amd64.deb /ferdi-out/Ferdi_`date +%Y-%b-%d`_amd64.deb
-mv /ferdi/ferdi /ferdi-out/Ferdi_`date +%Y-%b-%d`
+mv /ferdi/Ferdi-*.AppImage /ferdi-out/Ferdi-$GIT_SHA.AppImage
+mv /ferdi/ferdi-*.tar.gz /ferdi-out/Ferdi-$GIT_SHA.tar.gz
+mv /ferdi/ferdi-*.x86_64.rpm /ferdi-out/Ferdi-x86_64-$GIT_SHA.rpm
+mv /ferdi/ferdi_*_amd64.deb /ferdi-out/Ferdi-amd64-$GIT_SHA.deb
+mv /ferdi/ferdi /ferdi-out/Ferdi-$GIT_SHA
 ```
 
 ### Start development app

--- a/README.md
+++ b/README.md
@@ -231,6 +231,17 @@ We welcome all contributors. Please read the [contributing guidelines](CONTRIBUT
 
 Nightly releases are automatically triggered every day ([details](https://github.com/getferdi/ferdi/pull/990)) and available in [getferdi/nightlies](https://github.com/getferdi/nightlies/releases). Maintainers still need to manually publish the draft releases as pre-releases for now.
 
+**🔥🔥 UPDATE ON NIGHTLIES 🔥🔥**
+
+1. Since the nightly builds are broken for now, one of the active contributors is sharing builds that are built directly from source in [this location](https://drive.google.com/drive/folders/1mJmKbhpVHdb066IHlrdYiD8TG9wlmuBv?usp=sharing). You are free to use these and report any bugs - please be sure to specify *all the information* that shows up in the *About Ferdi* dialog on your installation. Please also upvote [this issue](https://github.com/getferdi/ferdi/issues/1254) where the broken nightly CI process is being tracked.
+2. Since this is being done on a volunteer basis AND being built from the source code, please be aware that there might be some bugs (introduced rarely - completely unintentionally). We will try to vet the builds before uploading them for your use. But, YMMV.
+3. Since the builds are being built from source, they will contain the latest and greatest of the application code as well as the recipes code - so, please be sure to test and log bugs for anything that is not working.
+4. For macOS users on Catalina or above, please be aware that the OS does not recognize unsigned applications that are not downloaded from the Mac App Store. To work around this issue, you will have to run the following command:
+
+```bash
+sudo xattr -rd com.apple.quarantine <path/to/Ferdi.app>
+```
+
 ## Troubleshooting recipes (self-help)
 
 One of the issues being raised by the awesome users of Ferdi is that certain service-functionalities do not work. As good example of this is either the unread count (badge) stops working for specific services or the gmail logins don't work anymore. (These are just 2 of the most common problems reported).


### PR DESCRIPTION
### Description
Updated with url of the gDrive folder where I am uploading artifacts daily.

### Motivation and Context
Easier to point to this url than typing all info into each and every issue that is logged.

### Screenshots
<img width="1275" alt="Screen Shot 2021-05-16 at 4 18 53 PM" src="https://user-images.githubusercontent.com/69629/118394921-445f9900-b665-11eb-9963-e3fa96688b61.png">


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally