### PR TITLE
Revert "Fix nodejs_version and trigger AppVeyor nightly build [skip ci]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ cache:
 image: Visual Studio 2019
 
 environment:
-  nodejs_version: "14.15.0"
+  nodejs_version: "14.16.1"
 
 install:
   - appveyor-retry git submodule update --init --recursive


### PR DESCRIPTION
### Description
This reverts commit 0069fea2f8e8c3cec9d46058d3b64aeae556f523.

### Motivation and Context
The same url linked shows that appveyor supports node 14.16.1

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally