### PR TITLE
Fixing stale reference to npm module that has been removed

### DIFF
--- a/build-helpers/entitlements.mas.inherit.plist
+++ b/build-helpers/entitlements.mas.inherit.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
-	  <true/>
+    <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>

--- a/build-helpers/entitlements.mas.plist
+++ b/build-helpers/entitlements.mas.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
     <key>com.apple.security.cs.allow-jit</key>
-	  <true/>
+    <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -66,5 +66,4 @@ protocols:
 
 asarUnpack:
   - ./recipes
-  - ./node_modules/mac-screen-capture-permissions
   - ./assets/images/taskbar


### PR DESCRIPTION
### Description
Removed reference to `mac-screen-capture-permissions` node module.

### Motivation and Context
Unsure of what side-effects might have occurred due to stale reference.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally