### PR TITLE
Use X-Franz headers to talk to the server

### DIFF
--- a/src/api/utils/auth.js
+++ b/src/api/utils/auth.js
@@ -8,11 +8,11 @@ export const prepareAuthRequest = (options = { method: 'GET' }, auth = true) => 
     mode: 'cors',
     headers: Object.assign({
       'Content-Type': 'application/json',
-      'X-Ferdi-Source': 'desktop',
-      'X-Ferdi-Version': app.getVersion(),
-      'X-Ferdi-platform': process.platform,
-      'X-Ferdi-Timezone-Offset': new Date().getTimezoneOffset(),
-      'X-Ferdi-System-Locale': app.getLocale(),
+      'X-Franz-Source': 'desktop',
+      'X-Franz-Version': app.getVersion(),
+      'X-Franz-platform': process.platform,
+      'X-Franz-Timezone-Offset': new Date().getTimezoneOffset(),
+      'X-Franz-System-Locale': app.getLocale(),
     }, options.headers),
   });
 


### PR DESCRIPTION
1fcfccd broke communication with the internal server by using X-Ferdi
headers instead of X-Franz headers on HTTP requests.
For compatibility reasons, we retain the X-Franz headers insteaf of
X-Ferdi headers in the internal server.

This commits reverts the change to the headers to restore internal
server functionality.

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally