### PR TITLE
Downgraded 'electron-is-dev'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15260,9 +15260,9 @@
       }
     },
     "electron-is-dev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-2.0.0.tgz",
-      "integrity": "sha512-3X99K852Yoqu9AcW50qz3ibYBWY79/pBhlMCab8ToEWS48R0T9tyxRiQhwylE7zQdXrMnx2JKqUJyMPmt5FBqA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.1.0.tgz",
+      "integrity": "sha512-Z1qA/1oHNowGtSBIcWk0pcLEqYT/j+13xUw/MYOrBUOL4X7VN0i0KCTf5SqyvMPmW5pSPKbo28wkxMxzZ20YnQ=="
     },
     "electron-notarize": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "electron-fetch": "1.7.3",
     "electron-find": "1.0.6",
     "electron-hunspell": "1.1.2",
-    "electron-is-dev": "2.0.0",
+    "electron-is-dev": "1.1.0",
     "electron-react-titlebar": "0.8.2",
     "electron-updater": "4.3.9",
     "electron-util": "0.16.0",


### PR DESCRIPTION
### Description
Downgraded 'electron-is-dev' since that is causing Ferdi to start with a blank screen.

### Motivation and Context

### Screenshots

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally