### PR TITLE
Fixes #1436: Set the default value for the 'customUrl' while adding a service.

### DIFF
--- a/src/containers/settings/EditServiceScreen.js
+++ b/src/containers/settings/EditServiceScreen.js
@@ -238,7 +238,7 @@ export default @inject('stores', 'actions') @observer class EditServiceScreen ex
         customUrl: {
           label: intl.formatMessage(messages.customUrl),
           placeholder: 'https://',
-          value: service.customUrl,
+          value: service.customUrl || recipe.serviceURL,
           validators: [required, url],
         },
       });


### PR DESCRIPTION
### Description
Sets the default value while showing the Edit Settings screen for the `customUrl` field. The user is free to edit it farther before saving.

### Motivation and Context

### Screenshots

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally