### PR TITLE
Expose recipe version in 'Settings' dialog while adding or editing a service

### DIFF
--- a/src/components/settings/services/EditServiceForm.js
+++ b/src/components/settings/services/EditServiceForm.js
@@ -478,12 +478,16 @@ export default @observer class EditServiceForm extends Component {
                   onClick={() => openRecipeFile('user.js')}
                 />
               </div>
-              <p style={{ marginTop: 10 }}>
+              <p style={{ marginTop: 10, marginBottom: 10 }}>
                 <span className="mdi mdi-information" />
                 {intl.formatMessage(messages.recipeFileInfo)}
               </p>
             </>
           )}
+          <span style={{ fontStyle: 'italic', fontSize: '80%' }}>
+            Recipe version:
+            {recipe.version}
+          </span>
         </div>
         <div className="settings__controls">
           {/* Delete Button */}

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -312,7 +312,7 @@
 
   .settings__delete-button { right: 0; }
   .settings__open-recipe-file-button {
-    cursor:pointer; 
+    cursor:pointer;
     margin-right: 10px;
   }
   .settings__open-recipe-file-container {


### PR DESCRIPTION
### Description
Expose the recipe version while selecting, adding and editing a service.

### Motivation and Context
When end-users report problems with recipes, there is invariably a guess whether they are reporting while using the latest version of the recipe or not. Exposing this in the UI might enable us to pre-empt a back-and-forth and ask for such versions in the github template itself - thus saving turnaround time for resolution.

### Screenshots
<img width="498" alt="Screen Shot 2021-05-22 at 6 45 59 AM" src="https://user-images.githubusercontent.com/69629/119210458-c9b1d600-bac9-11eb-9ca0-ab8a9ac3fde4.png">
<img width="507" alt="Screen Shot 2021-05-22 at 6 46 14 AM" src="https://user-images.githubusercontent.com/69629/119210464-ccacc680-bac9-11eb-8d5d-09956272033d.png">

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally