### PR TITLE
Electron 13 support on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14118,9 +14118,9 @@
       "dev": true
     },
     "dbus-next": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/dbus-next/-/dbus-next-0.8.2.tgz",
-      "integrity": "sha512-E2wkbhZzzsgmY+jxIdeuhA1nVT697I5koRIRJTk3doTeukwtzqSFG89RC5XK8OsLG/eHDZ8PVNptUuEPkhdPbA==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/dbus-next/-/dbus-next-0.9.2.tgz",
+      "integrity": "sha512-tzQq/+wrTZ2yU+U5PoeXc97KABhX2v55C/T0finH3tSKYuI8H/SqppIFymBBrUHcK13LvEGY3vdj3ikPPenL5g==",
       "requires": {
         "@nornagon/put": "0.0.8",
         "abstract-socket": "^2.0.0",
@@ -27840,9 +27840,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "nanoid": {
       "version": "2.1.11",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "manage-translations": "node ./src/i18n/manage-translations.js",
     "prebuild": "preval-build-info-cli && gulp build",
     "build": "electron-builder",
-    "rebuild": "electron-rebuild",
+    "rebuild": "electron-rebuild --force-abi=98",
     "commit": "git-cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "contributors": "all-contributors",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "cld": "2.7.0",
     "css": "2.2.4",
     "darkreader": "4.7.15",
-    "dbus-next": "0.8.2",
+    "dbus-next": "0.9.2",
     "du": "^0.1.0",
     "electron-dl": "1.14.0",
     "electron-fetch": "1.7.3",


### PR DESCRIPTION
Bumps some dependencies to successfully build with the new Electron ABI and pins the Electron ABI version in `npm run start` to support Electron 13, which `node-abi` still considers unreleased (despite `13.0.0` being tagged as `latest` in npmjs).

The ABI version pin should be reverted once `node-abi` marks Electron 13 support as released.

### Screenshots
![electron13](https://user-images.githubusercontent.com/38888/119499165-ba02ed80-bd66-11eb-9815-e0f4c3ccbbf9.png)


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally