### PR TITLE
Added new entry in context menu: 'Download image'

### DIFF
--- a/src/webview/contextMenuBuilder.js
+++ b/src/webview/contextMenuBuilder.js
@@ -350,9 +350,8 @@ module.exports = class ContextMenuBuilder {
             (dataURL) => {
               const url = new window.URL(urlWithoutBlob);
               const fileName = url.pathname.substr(1);
-              const base64data = nativeImage.createFromDataURL(dataURL);
               ipcRenderer.send('download-file', {
-                content: base64data.toDataURL(),
+                content: dataURL,
                 fileOptions: {
                   name: fileName,
                   mime: 'image/png',

--- a/src/webview/contextMenuBuilder.js
+++ b/src/webview/contextMenuBuilder.js
@@ -341,7 +341,8 @@ module.exports = class ContextMenuBuilder {
 
     menu.append(copyImageUrl);
 
-    if (menuInfo.srcURL.startsWith('blob:')) {
+    // TODO: This doesn't seem to work on linux, so, limiting to Mac for now
+    if (isMac && menuInfo.srcURL.startsWith('blob:')) {
       const downloadImage = new MenuItem({
         label: this.stringTable.downloadImage(),
         click: () => {

--- a/src/webview/contextMenuBuilder.js
+++ b/src/webview/contextMenuBuilder.js
@@ -11,7 +11,7 @@ import { isMac } from '../environment';
 import { SEARCH_ENGINE_NAMES, SEARCH_ENGINE_URLS } from '../config';
 
 const {
-  clipboard, nativeImage, remote, shell,
+  clipboard, ipcRenderer, nativeImage, remote, shell,
 } = require('electron');
 
 const { URL } = require('url');
@@ -36,6 +36,7 @@ const contextMenuStringTable = {
   copyLinkUrl: () => 'Copy Link',
   copyImageUrl: () => 'Copy Image Address',
   copyImage: () => 'Copy Image',
+  downloadImage: () => 'Download Image',
   addToDictionary: () => 'Add to Dictionary',
   goBack: () => 'Go Back',
   goForward: () => 'Go Forward',
@@ -192,6 +193,7 @@ module.exports = class ContextMenuBuilder {
     this.addInspectElement(menu, menuInfo);
     this.processMenu(menu, menuInfo);
 
+    this.addSeparator(menu);
     this.goBack(menu);
     this.goForward(menu);
     this.copyPageUrl(menu);
@@ -214,6 +216,7 @@ module.exports = class ContextMenuBuilder {
     this.addInspectElement(menu, menuInfo);
     this.processMenu(menu, menuInfo);
 
+    this.addSeparator(menu);
     this.goBack(menu);
     this.goForward(menu);
     this.copyPageUrl(menu);
@@ -337,6 +340,32 @@ module.exports = class ContextMenuBuilder {
     });
 
     menu.append(copyImageUrl);
+
+    if (menuInfo.srcURL.startsWith('blob:')) {
+      const downloadImage = new MenuItem({
+        label: this.stringTable.downloadImage(),
+        click: () => {
+          const urlWithoutBlob = menuInfo.srcURL.substr(5);
+          this.convertImageToBase64(menuInfo.srcURL,
+            (dataURL) => {
+              const url = new window.URL(urlWithoutBlob);
+              const fileName = url.pathname.substr(1);
+              const base64data = nativeImage.createFromDataURL(dataURL);
+              ipcRenderer.send('download-file', {
+                content: base64data.toDataURL(),
+                fileOptions: {
+                  name: fileName,
+                  mime: 'image/png',
+                },
+              });
+            });
+          this.sendNotificationOnClipboardEvent(`Image downloaded: ${urlWithoutBlob}`);
+        },
+      });
+
+      menu.append(downloadImage);
+    }
+
     return menu;
   }
 


### PR DESCRIPTION
### Description
Currently, to download an image (specifically a blob), the user needs to right-click on the image and select "Copy image" or "Copy image URL". Then they need to manually open a browser and paste the data in - and finally select whatever process/option to download the image. Instead, this context menu item does the same from within Ferdi.

### Motivation and Context

### Screenshots
<img width="510" alt="Screen Shot 2021-05-26 at 11 38 09 AM" src="https://user-images.githubusercontent.com/69629/119612588-b2e8e780-be19-11eb-8aea-5a63d9b192ff.png">

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally