### PR TITLE
Use electronuserland base Docker image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,10 +68,12 @@ v8.0.0
 
 The version [2.23.0](https://github.com/git-for-windows/git/releases/tag/v2.23.0.windows.1) for Git is working fine for development. You can then use the console from Git to do the development procedure.
 
+_Note:_ This list can likely get outdated. If so, please refer to the specific version of the [electronuserland builder](https://hub.docker.com/r/electronuserland/builder) that we use in our [Dockerfile](./Dockerfile).
+
 #### Debian/Ubuntu
 
 ```bash
-apt install libx11-dev libxext-dev libxss-dev libxkbfile-dev rpm
+apt install ca-certificates curl netbase wget tzdata rpm
 ```
 
 #### Fedora

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM node:14 as builder
-
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends libx11-dev libxext-dev libxss-dev libxkbfile-dev rpm \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+FROM electronuserland/builder:14 as builder
 
 WORKDIR /usr/src/ferdi
 


### PR DESCRIPTION
### Description
Use the default base image published by the `electron-build` project - so that we don't need to manually track all system deps (nodejs, apt packages, etc). And the version of nodejs, etc is guaranteed to work.

Of course, this will mean that we might sometimes lag behind in the adoption of newer versions of nodejs, etc - but, at this point, its a safe bet to say that they are also quite responsive in adopting newer versions of system deps and so this should not be a problem per se.

### Motivation and Context
Upgrade path

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally