### PR TITLE
Recipe context isolation

### DIFF
--- a/src/components/services/content/ServiceWebview.js
+++ b/src/components/services/content/ServiceWebview.js
@@ -83,7 +83,7 @@ class ServiceWebview extends Component {
         useragent={service.userAgent}
         disablewebsecurity={service.recipe.disablewebsecurity ? true : undefined}
         allowpopups
-        webpreferences={`spellcheck=${isSpellcheckerEnabled ? 1 : 0}, contextIsolation=false`}
+        webpreferences={`spellcheck=${isSpellcheckerEnabled ? 1 : 0}`}
       />
     );
   }

--- a/src/index.js
+++ b/src/index.js
@@ -449,6 +449,36 @@ ipcMain.on('feature-basic-auth-cancel', () => {
   authCallback = noop;
 });
 
+// Handle synchronous messages from service webviews.
+
+ipcMain.on('find-in-page', (e, text, options) => {
+  const { sender: webContents } = e;
+  if (webContents !== mainWindow.webContents && typeof (text) === 'string') {
+    const sanitizedOptions = {};
+    for (const option of ['forward', 'findNext', 'matchCase']) {
+      if (option in options) {
+        sanitizedOptions[option] = !!options[option];
+      }
+    }
+    const requestId = webContents.findInPage(text, sanitizedOptions);
+    debug('Find in page', text, options, requestId);
+    e.returnValue = requestId;
+  } else {
+    e.returnValue = null;
+  }
+});
+
+ipcMain.on('stop-find-in-page', (e, action) => {
+  const { sender: webContents } = e;
+  if (webContents !== mainWindow.webContents) {
+    const validActions = ['clearSelection', 'keepSelection', 'activateSelection'];
+    if (validActions.includes(action)) {
+      webContents.stopFindInPage(action);
+    }
+  }
+  e.returnValue = null;
+});
+
 // Quit when all windows are closed.
 app.on('window-all-closed', () => {
   // On OS X it is common for applications and their menu bar

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -275,11 +275,17 @@ export default class Service {
       debug(this.name, 'modifyRequestHeaders is not defined in the recipe');
     }
 
-    this.webview.addEventListener('ipc-message', e => handleIPCMessage({
-      serviceId: this.id,
-      channel: e.channel,
-      args: e.args,
-    }));
+    this.webview.addEventListener('ipc-message', (e) => {
+      if (e.channel === 'inject-js-unsafe') {
+        this.webview.executeJavaScript(e.args[0]);
+      } else {
+        handleIPCMessage({
+          serviceId: this.id,
+          channel: e.channel,
+          args: e.args,
+        });
+      }
+    });
 
     this.webview.addEventListener('new-window', (event, url, frameName, options) => {
       debug('new-window', event, url, frameName, options);

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -275,9 +275,9 @@ export default class Service {
       debug(this.name, 'modifyRequestHeaders is not defined in the recipe');
     }
 
-    this.webview.addEventListener('ipc-message', (e) => {
+    this.webview.addEventListener('ipc-message', async (e) => {
       if (e.channel === 'inject-js-unsafe') {
-        this.webview.executeJavaScript(e.args[0]);
+        await this.webview.executeJavaScript(`"use strict"; (() => { ${e.args[0]} })();`);
       } else {
         handleIPCMessage({
           serviceId: this.id,

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -277,7 +277,7 @@ export default class Service {
 
     this.webview.addEventListener('ipc-message', async (e) => {
       if (e.channel === 'inject-js-unsafe') {
-        await this.webview.executeJavaScript(`"use strict"; (() => { ${e.args[0]} })();`);
+        await Promise.all(e.args.map(script => this.webview.executeJavaScript(`"use strict"; (() => { ${script} })();`)));
       } else {
         handleIPCMessage({
           serviceId: this.id,

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -340,6 +340,11 @@ export default class Service {
       this.hasCrashed = true;
     });
 
+    this.webview.addEventListener('found-in-page', ({ result }) => {
+      debug('Found in page', result);
+      this.webview.send('found-in-page', result);
+    });
+
     webviewWebContents.on('login', (event, request, authInfo, callback) => {
       // const authCallback = callback;
       debug('browser login event', authInfo);

--- a/src/webview/badge.js
+++ b/src/webview/badge.js
@@ -1,0 +1,33 @@
+const { ipcRenderer } = require('electron');
+
+const debug = require('debug')('Ferdi:Plugin:BadgeHandler');
+
+export class BadgeHandler {
+  constructor() {
+    this.countCache = {
+      direct: 0,
+      indirect: 0,
+    };
+  }
+
+  setBadge(direct, indirect) {
+    if (this.countCache.direct === direct
+        && this.countCache.indirect === indirect) return;
+
+    // Parse number to integer
+    // This will correct errors that recipes may introduce, e.g.
+    // by sending a String instead of an integer
+    const directInt = parseInt(direct, 10);
+    const indirectInt = parseInt(indirect, 10);
+
+    const count = {
+      direct: Math.max(directInt, 0),
+      indirect: Math.max(indirectInt, 0),
+    };
+
+    ipcRenderer.sendToHost('message-counts', count);
+    Object.assign(this.countCache, count);
+
+    debug('Sending badge count to host', count);
+  }
+}

--- a/src/webview/find.js
+++ b/src/webview/find.js
@@ -1,0 +1,23 @@
+import { ipcRenderer } from 'electron';
+import { FindInPage as ElectronFindInPage } from 'electron-find';
+
+// Shim to expose webContents functionality to electron-find without @electron/remote
+const webContentsShim = {
+  findInPage: (text, options = {}) => ipcRenderer.sendSync('find-in-page', text, options),
+  stopFindInPage: (action) => {
+    ipcRenderer.sendSync('stop-find-in-page', action);
+  },
+  on: (eventName, listener) => {
+    if (eventName === 'found-in-page') {
+      ipcRenderer.on('found-in-page', (_, result) => {
+        listener({ sender: this }, result);
+      });
+    }
+  },
+};
+
+export default class FindInPage extends ElectronFindInPage {
+  constructor(options = {}) {
+    super(webContentsShim, options);
+  }
+}

--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import { pathExistsSync, readFile } from 'fs-extra';
+import { exists, pathExistsSync, readFile } from 'fs-extra';
 
 const debug = require('debug')('Ferdi:Plugin:RecipeWebview');
 
@@ -68,8 +68,8 @@ class RecipeWebview {
 
   injectJSUnsafe(...files) {
     Promise.all(files.map(async (file) => {
-      if (await fs.exists(file)) {
-        const data = await fs.readFile(file, 'utf8');
+      if (await exists(file)) {
+        const data = await readFile(file, 'utf8');
         return data;
       }
       debug('Script not found', file);

--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -69,8 +69,10 @@ class RecipeWebview {
   injectJSUnsafe(...files) {
     files.forEach(async (file) => {
       if (await fs.exists(file)) {
-        const data = await fs.readFile(file);
+        const data = await fs.readFile(file, 'utf8');
         ipcRenderer.sendToHost('inject-js-unsafe', data);
+
+        debug('Inject script to main world', data);
       }
     });
   }

--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -4,12 +4,8 @@ import { pathExistsSync, readFile } from 'fs-extra';
 const debug = require('debug')('Ferdi:Plugin:RecipeWebview');
 
 class RecipeWebview {
-  constructor(notificationsHandler) {
-    this.countCache = {
-      direct: 0,
-      indirect: 0,
-    };
-
+  constructor(badgeHandler, notificationsHandler) {
+    this.badgeHandler = badgeHandler;
     this.notificationsHandler = notificationsHandler;
 
     ipcRenderer.on('poll', () => {
@@ -47,24 +43,7 @@ class RecipeWebview {
    *                          me directly to me eg. in a channel
    */
   setBadge(direct = 0, indirect = 0) {
-    if (this.countCache.direct === direct
-      && this.countCache.indirect === indirect) return;
-
-    // Parse number to integer
-    // This will correct errors that recipes may introduce, e.g.
-    // by sending a String instead of an integer
-    const directInt = parseInt(direct, 10);
-    const indirectInt = parseInt(indirect, 10);
-
-    const count = {
-      direct: Math.max(directInt, 0),
-      indirect: Math.max(indirectInt, 0),
-    };
-
-    ipcRenderer.sendToHost('message-counts', count);
-    Object.assign(this.countCache, count);
-
-    debug('Sending badge count to host', count);
+    this.badgeHandler.setBadge(direct, indirect);
   }
 
   /**

--- a/src/webview/notifications.js
+++ b/src/webview/notifications.js
@@ -3,49 +3,65 @@ import uuidV1 from 'uuid/v1';
 
 const debug = require('debug')('Ferdi:Notifications');
 
-class Notification {
-  static permission = 'granted';
+export class NotificationsHandler {
+  onNotify = data => data;
 
-  constructor(title = '', options = {}) {
-    debug('New notification', title, options);
-    this.title = title;
-    this.options = options;
-    this.notificationId = uuidV1();
+  displayNotification(title, options) {
+    return new Promise((resolve) => {
+      debug('New notification', title, options);
 
-    ipcRenderer.sendToHost('notification', this.onNotify({
-      title: this.title,
-      options: this.options,
-      notificationId: this.notificationId,
-    }));
+      const notificationId = uuidV1();
 
-    ipcRenderer.once(`notification-onclick:${this.notificationId}`, () => {
-      if (typeof this.onclick === 'function') {
-        this.onclick();
-      }
+      ipcRenderer.sendToHost('notification', this.onNotify({
+        title,
+        options,
+        notificationId,
+      }));
+
+      ipcRenderer.once(`notification-onclick:${notificationId}`, () => {
+        resolve();
+      });
     });
   }
-
-  static requestPermission(cb = null) {
-    if (!cb) {
-      return new Promise((resolve) => {
-        resolve(Notification.permission);
-      });
-    }
-
-    if (typeof (cb) === 'function') {
-      return cb(Notification.permission);
-    }
-
-    return Notification.permission;
-  }
-
-  onNotify(data) {
-    return data;
-  }
-
-  onClick() {}
-
-  close() {}
 }
 
-window.Notification = Notification;
+export const notificationsClassDefinition = `(() => {
+  class Notification {
+    static permission = 'granted';
+
+    constructor(title = '', options = {}) {
+      this.title = title;
+      this.options = options;
+      window.ferdi.displayNotification(title, options)
+        .then(() => {
+          if (typeof (this.onClick) === 'function') {
+            this.onClick();
+          }
+        });
+    }
+
+    static requestPermission(cb = null) {
+      if (!cb) {
+        return new Promise((resolve) => {
+          resolve(Notification.permission);
+        });
+      }
+
+      if (typeof (cb) === 'function') {
+        return cb(Notification.permission);
+      }
+
+      return Notification.permission;
+    }
+
+    onNotify(data) {
+      return data;
+    }
+
+    onClick() {}
+
+    close() {}
+  }
+
+  window.Notification = Notification;
+})();`;

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -83,7 +83,7 @@ window.open = (url, frameName, features) => {
   }
 };
 
-window.log = isDevMode ? console.log : () => {};
+window.log = isDevMode ? (...args) => console.log(...args) : () => {};
 
 // We can't override APIs here, so we first expose functions via window.ferdi,
 // then overwrite the corresponding field of the window object by injected JS.

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -1,11 +1,9 @@
 /* eslint-disable import/first */
 import { contextBridge, ipcRenderer } from 'electron';
-import { getCurrentWebContents } from '@electron/remote';
 import path from 'path';
 import { autorun, computed, observable } from 'mobx';
 import fs from 'fs-extra';
 import { debounce } from 'lodash';
-import { FindInPage } from 'electron-find';
 
 // For some services darkreader tries to use the chrome extension message API
 // This will cause the service to fail loading
@@ -24,8 +22,9 @@ import RecipeWebview from './lib/RecipeWebview';
 import Userscript from './lib/Userscript';
 
 import { BadgeHandler } from './badge';
-import { injectDarkModeStyle, isDarkModeStyleInjected, removeDarkModeStyle } from './darkmode';
 import contextMenu from './contextMenu';
+import { injectDarkModeStyle, isDarkModeStyleInjected, removeDarkModeStyle } from './darkmode';
+import FindInPage from './find';
 import { NotificationsHandler, notificationsClassDefinition } from './notifications';
 import { getDisplayMediaSelector, screenShareCss, screenShareJs } from './screenshare';
 import { switchDict, getSpellcheckerLocaleByFuzzyIdentifier } from './spellchecker';
@@ -161,7 +160,7 @@ class RecipeController {
     autorun(() => this.update());
 
     document.addEventListener('DOMContentLoaded', () => {
-      this.findInPage = new FindInPage(getCurrentWebContents(), {
+      this.findInPage = new FindInPage({
         inputFocusColor: '#CE9FFC',
         textColor: '#212121',
       });

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -92,11 +92,10 @@ contextBridge.exposeInMainWorld('ferdi', {
   getDisplayMediaSelector,
 });
 
-ipcRenderer.sendToHost('inject-js-unsafe', `
-window.open = window.ferdi.open;
-${notificationsClassDefinition}
-${screenShareJs}
-`);
+ipcRenderer.sendToHost('inject-js-unsafe',
+  'window.open = window.ferdi.open;',
+  notificationsClassDefinition,
+  screenShareJs);
 
 class RecipeController {
   @observable settings = {

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -30,7 +30,7 @@ import { NotificationsHandler, notificationsClassDefinition } from './notificati
 import { getDisplayMediaSelector, screenShareCss, screenShareJs } from './screenshare';
 import { switchDict, getSpellcheckerLocaleByFuzzyIdentifier } from './spellchecker';
 
-import { DEFAULT_APP_SETTINGS, isDevMode } from '../environment';
+import { DEFAULT_APP_SETTINGS } from '../environment';
 
 const debug = require('debug')('Ferdi:Plugin');
 
@@ -83,13 +83,10 @@ window.open = (url, frameName, features) => {
   }
 };
 
-window.log = isDevMode ? (...args) => console.log(...args) : () => {};
-
 // We can't override APIs here, so we first expose functions via window.ferdi,
 // then overwrite the corresponding field of the window object by injected JS.
 contextBridge.exposeInMainWorld('ferdi', {
   open: window.open,
-  log: window.log,
   setBadge: (direct, indirect) => badgeHandler.setBadge(direct || 0, indirect || 0),
   displayNotification: (title, options) => notificationsHandler.displayNotification(title, options),
   getDisplayMediaSelector,
@@ -97,7 +94,6 @@ contextBridge.exposeInMainWorld('ferdi', {
 
 ipcRenderer.sendToHost('inject-js-unsafe', `
 window.open = window.ferdi.open;
-window.log = window.ferdi.log;
 ${notificationsClassDefinition}
 ${screenShareJs}
 `);


### PR DESCRIPTION
### Description

This PR lets us enable Electron [context isolation](https://www.electronjs.org/docs/tutorial/context-isolation) in the services. As a result, recipe code will run in the "isolated world", while normal Javascript loaded by the services will run in the "main world". Electron restricts the objects that can be exchanged between the two worlds to protect native APIs.

As a general architecture, Ferdi will expose a `window.ferdi` object with API endpoints for native Electron functionality like window opening, screen sharing, and notifications using the Electron [`contextBridge`](https://www.electronjs.org/docs/api/context-bridge). Because services expect these APIs in their usual places (and on `window.ferdi`), we inject additional "unsafe" (not context isolated) Javascript code into the service with [`webContext.executeJavaScript`](https://www.electronjs.org/docs/api/web-contents#contentsexecutejavascriptcode-usergesture) to hook up the APIs to the `window` object. More complex functionalities have a substantial shim in the unsafe code, as the communication capabilities of `contextBridge` are somewhat limited.

Recipes are also given the capability to patch the `window` object with the new `injectJSUnsafe` API. This mirrors the `injectCSS` API, i.e., the recipe ships the injected code in an additional file (e.g., `webview-unsafe.js`). As a special case, there's also a `window.ferdi.setBadge` function to update the service badge when it's only possible from the main world.

See https://github.com/getferdi/recipes/pull/535 for the required recipe changes, which should be merged simultaneously with this PR.

I have tested the recipe changes for `msteams` and `skype`. I also spotted required changes in `fastmail`, `googlecalendar` and `googledrive`, which still needs to be tested. Any other recipe also needs extensive testing, as this is a huge change to the capabilities of the recipes and the available API surfaces.

### Motivation and Context

[Context isolation](https://www.electronjs.org/docs/tutorial/context-isolation) is an important security feature in Electron. It lets us to avoid exposing the internals of Ferdi to the services, e.g., it prevents untrusted scripts in the services gaining access to the users' filesystem.

As a next step, we should try to [follow Electron best practices](https://nornagon.medium.com/electrons-remote-module-considered-harmful-70d69500f31) and remove uses of the `@electron/remote` module from the recipes and switch on [Chromium sandboxing](https://www.electronjs.org/docs/tutorial/sandbox), but that will be even more involved. An additional valuable resource is the [Electron security guide](https://www.electronjs.org/docs/tutorial/security).

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [ ] I tested/previewed my changes locally