### PR TITLE
Cosmetic fixes

### DIFF
--- a/src/features/appearance/index.js
+++ b/src/features/appearance/index.js
@@ -18,6 +18,12 @@ function setAppearance(style) {
   styleElement.innerHTML = style;
 }
 
+// See https://github.com/Qix-/color/issues/53#issuecomment-656590710
+function darkenAbsolute(originalColor, absoluteChange) {
+  const originalLightness = originalColor.lightness();
+  return originalColor.lightness(originalLightness - absoluteChange);
+}
+
 function generateAccentStyle(accentColorStr) {
   let style = '';
 
@@ -35,10 +41,10 @@ function generateAccentStyle(accentColorStr) {
   } catch (e) {
     // Ignore invalid accent color.
   }
-  const darkerColorStr = accentColor.darken(0.05).hex();
+  const darkerColorStr = darkenAbsolute(accentColor, 5).hex();
   style += `
     a.button:hover, button.button:hover {
-      background: ${accentColor.darken(0.1).hex()};
+      background: ${darkenAbsolute(accentColor, 10).hex()};
     }
 
     .franz-form__button:hover,

--- a/src/styles/badge.scss
+++ b/src/styles/badge.scss
@@ -4,7 +4,6 @@
   background: $dark-theme-gray;
   border-radius: $theme-border-radius-small;
   color: $dark-theme-gray-lightest;
-  margin-right: 10px;
 
   &.badge--primary,
   &.badge--premium {

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -135,13 +135,13 @@
 
 .settings {
   border-radius: $theme-border-radius;
-  // box-shadow: 0 20px 50px rgba(black, .5);
+  box-shadow: 0 20px 50px rgba($dark-theme-black, .5);
   display: flex;
   height: 100%;
   max-height: 720px;
   max-width: 900px;
   min-height: 400px;
-  // overflow: hidden;
+  overflow: hidden;
   position: relative;
   width: 100%;
   z-index: 9999;
@@ -245,7 +245,6 @@
     position: absolute;
     right: 0;
     transition: background $theme-transition-time;
-    border-top-right-radius: $theme-border-radius;
     cursor: pointer;
 
     &::before { cursor: pointer; }
@@ -454,7 +453,6 @@
   border-top-left-radius: $theme-border-radius;;
   border-bottom-left-radius: $theme-border-radius;;
   overflow: hidden;
-  box-shadow: 0 20px 50px rgba($dark-theme-black, .5);
 
   .settings-navigation__link {
     align-items: center;

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -79,16 +79,16 @@
       }
 
       .badge {
-        background: $dark-theme-gray-lighter;
-        color: $dark-theme-gray-smoke;
+        background: $dark-theme-gray;
+        color: $dark-theme-gray-lightest;
       }
 
       &:hover {
         background: darken($dark-theme-gray-darker, 5%);
 
         .badge {
-          background: $dark-theme-gray-lighter;
-          color: $dark-theme-gray-smoke;
+          background: $dark-theme-gray;
+          color: $dark-theme-gray-lightest;
         }
       }
 
@@ -98,11 +98,11 @@
 
       &.is-active {
         background: $dark-theme-gray;
-        color: $dark-theme-gray-smoke;
+        color: $dark-theme-gray-lightest;
 
         .badge {
           background: $dark-theme-gray-lighter;
-          color: $dark-theme-gray-smoke;
+          color: #000;
         }
       }
     }
@@ -466,11 +466,17 @@
     transition: background $theme-transition-time, color $theme-transition-time;
     border-bottom: 1px solid darken($theme-gray-lightest, 3%);
 
+    .badge {
+      background: $theme-gray-light;
+      color: #FFF;
+    }
+
     &:hover {
-      background: darken($theme-gray-lightest, 5%);
+      background: darken($theme-gray-lightest, 8%);
 
       .badge {
-        background: #FFF;
+        background: $theme-gray-light;
+        color: #FFF;
       }
     }
 
@@ -488,7 +494,6 @@
   .settings-navigation__expander { flex: 1; }
 
   .badge {
-
     display: initial;
     transition: background $theme-transition-time, color $theme-transition-time;
   }

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -33,7 +33,8 @@
   width: $theme-sidebar-width;
 
   &.is-active {
-    background: lighten($theme-brand-primary, 35%);
+    background: change-color($theme-brand-primary,
+                             $lightness: min(lightness($theme-brand-primary) * 1.35, 100));
     border-left-width: 4px;
     border-left-style: solid;
     color: $theme-brand-primary;


### PR DESCRIPTION
### Description

* Fixes the confusion around color adjustment functions in SCSS and JS, so now the colors are lightened/darkened by the same amount both with the default and with a custom accent color.
* Extends the shadow of the settings dialog to the whole dialog (previously, only the sidebar had a shadow).
* Makes the service and workspace count badges in the settings dialog more readable.

### Screenshots
![Screenshot with light mode](https://user-images.githubusercontent.com/38888/120083359-6aa32100-c0c8-11eb-8e2f-2b792b29b1f0.png)
![Screenshot with dark mode](https://user-images.githubusercontent.com/38888/120083368-80b0e180-c0c8-11eb-83d3-4b74ee6d5992.png)


### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally