### PR TITLE
Change Linux executable name to Ferdi (fix #1469)

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -49,7 +49,7 @@ win:
 linux:
   icon: ./build-helpers/images/icons
   category: Network;InstantMessaging;
-  executableName: ferdi
+  executableName: Ferdi
   synopsis: "Messaging app for WhatsApp, Slack, Telegram, Gmail, Hangouts and many many more."
   description: "Ferdi is your messaging app / former Emperor of Austria and combines chat & messaging services into one application. Ferdi currently supports Slack, WhatsApp, Gmail, Facebook Messenger, Telegram, Google Hangouts, GroupMe, Skype and many more. You can download Ferdi for free for Mac & Windows."
   target:


### PR DESCRIPTION
In the .deb package, the post-inst script incorrectly refers to the npm product name instead of th electron-builder executable name. We set the executable name equal to the product name to avoid the clash.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally