### PR TITLE
Fixing opening links in the 5.50+ versions of Ferdi

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -438,7 +438,7 @@ ipcMain.on('feature-basic-auth-credentials', (e, { user, password }) => {
   authCallback = noop;
 });
 
-ipcMain.on('open-browser-window', (e, { disposition, url }, serviceId) => {
+ipcMain.on('open-browser-window', (e, { disposition, url, serviceId }) => {
   if (disposition === 'foreground-tab') {
     const serviceSession = session.fromPartition(`persist:service-${serviceId}`);
     const child = new BrowserWindow({ parent: mainWindow, webPreferences: { session: serviceSession } });

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -288,7 +288,11 @@ export default class Service {
     this.webview.addEventListener('new-window', (event, url, frameName, options) => {
       debug('new-window', event, url, frameName, options);
       if (event.disposition === 'foreground-tab') {
-        ipcRenderer.send('open-browser-window', event, this.id);
+        ipcRenderer.send('open-browser-window', {
+          disposition: event.disposition,
+          url: event.url,
+          serviceId: this.id,
+        });
       } else {
         openWindow({
           event,

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -6,6 +6,7 @@ import path from 'path';
 
 import userAgent from '../helpers/userAgent-helpers';
 import { TODOS_RECIPE_ID, todosStore } from '../features/todos';
+import { isValidExternalURL } from '../helpers/url-helpers';
 
 const debug = require('debug')('Ferdi:Service');
 
@@ -287,6 +288,9 @@ export default class Service {
 
     this.webview.addEventListener('new-window', (event, url, frameName, options) => {
       debug('new-window', event, url, frameName, options);
+      if (!isValidExternalURL(event.url)) {
+        return;
+      }
       if (event.disposition === 'foreground-tab') {
         ipcRenderer.send('open-browser-window', {
           disposition: event.disposition,


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
Starting electron 9, support for non JS object in ipcRenderer is been removed. There was one instance in the code, that was sending a browserEvent to open the links and that was throwing an error.

https://www.electronjs.org/docs/breaking-changes#behavior-changed-sending-non-js-objects-over-ipc-now-throws-an-exception

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getferdi/ferdi/issues/1339

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally