### PR TITLE
Expose Chrome version to todos webview (fix #1211)

### DIFF
--- a/src/features/todos/components/TodosWebview.js
+++ b/src/features/todos/components/TodosWebview.js
@@ -110,6 +110,7 @@ class TodosWebview extends Component {
     resize: PropTypes.func.isRequired,
     width: PropTypes.number.isRequired,
     minWidth: PropTypes.number.isRequired,
+    userAgent: PropTypes.string.isRequired,
     isTodosIncludedInCurrentPlan: PropTypes.bool.isRequired,
     stores: PropTypes.shape({
       settings: PropTypes.instanceOf(SettingsStore).isRequired,
@@ -207,6 +208,7 @@ class TodosWebview extends Component {
       classes,
       isTodosServiceActive,
       isVisible,
+      userAgent,
       isTodosIncludedInCurrentPlan,
       stores,
     } = this.props;
@@ -268,6 +270,7 @@ class TodosWebview extends Component {
             partition={TODOS_PARTITION_ID}
             preload="./features/todos/preload.js"
             ref={(webview) => { this.webview = webview ? webview.view : null; }}
+            useragent={userAgent}
             src={todoUrl}
           />
           )

--- a/src/features/todos/components/TodosWebview.js
+++ b/src/features/todos/components/TodosWebview.js
@@ -14,8 +14,6 @@ import Appear from '../../../components/ui/effects/Appear';
 import UpgradeButton from '../../../components/ui/UpgradeButton';
 import { TODOS_PARTITION_ID } from '..';
 
-import userAgent from '../../../helpers/userAgent-helpers';
-
 // NOTE: https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
 function validURL(str) {
   let url;
@@ -139,11 +137,6 @@ class TodosWebview extends Component {
     this.node.addEventListener('mousemove', this.resizePanel.bind(this));
     this.node.addEventListener('mouseup', this.stopResize.bind(this));
     this.node.addEventListener('mouseleave', this.stopResize.bind(this));
-
-    const webViewInstance = this;
-    this.webview.addEventListener('dom-ready', () => {
-      webViewInstance.webview.setUserAgent(userAgent(true));
-    });
   }
 
   startResize = (event) => {

--- a/src/features/todos/containers/TodosScreen.js
+++ b/src/features/todos/containers/TodosScreen.js
@@ -27,6 +27,7 @@ class TodosScreen extends Component {
           width={todosStore.width}
           minWidth={TODOS_MIN_WIDTH}
           resize={width => todoActions.resize({ width })}
+          userAgent={todosStore.userAgent}
           isTodosIncludedInCurrentPlan
         />
       </ErrorBoundary>

--- a/src/helpers/userAgent-helpers.js
+++ b/src/helpers/userAgent-helpers.js
@@ -19,6 +19,10 @@ function linux() {
   return 'X11; Ubuntu; Linux x86_64';
 }
 
+export function isChromeless(url) {
+  return url.startsWith('https://accounts.google.com');
+}
+
 export default function userAgent(removeChromeVersion = false, addFerdiVersion = false) {
   let platformString = '';
 

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -6412,39 +6412,39 @@
         "defaultMessage": "!!!Franz Todos are available to premium users now!",
         "end": {
           "column": 3,
-          "line": 36
+          "line": 34
         },
         "file": "src/features/todos/components/TodosWebview.js",
         "id": "feature.todos.premium.info",
         "start": {
           "column": 15,
-          "line": 33
+          "line": 31
         }
       },
       {
         "defaultMessage": "!!!Upgrade Account",
         "end": {
           "column": 3,
-          "line": 40
+          "line": 38
         },
         "file": "src/features/todos/components/TodosWebview.js",
         "id": "feature.todos.premium.upgrade",
         "start": {
           "column": 14,
-          "line": 37
+          "line": 35
         }
       },
       {
         "defaultMessage": "!!!Everyone else will have to wait a little longer.",
         "end": {
           "column": 3,
-          "line": 44
+          "line": 42
         },
         "file": "src/features/todos/components/TodosWebview.js",
         "id": "feature.todos.premium.rollout",
         "start": {
           "column": 15,
-          "line": 41
+          "line": 39
         }
       }
     ],

--- a/src/i18n/messages/src/features/todos/components/TodosWebview.json
+++ b/src/i18n/messages/src/features/todos/components/TodosWebview.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Franz Todos are available to premium users now!",
     "file": "src/features/todos/components/TodosWebview.js",
     "start": {
-      "line": 33,
+      "line": 31,
       "column": 15
     },
     "end": {
-      "line": 36,
+      "line": 34,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!Upgrade Account",
     "file": "src/features/todos/components/TodosWebview.js",
     "start": {
-      "line": 37,
+      "line": 35,
       "column": 14
     },
     "end": {
-      "line": 40,
+      "line": 38,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Everyone else will have to wait a little longer.",
     "file": "src/features/todos/components/TodosWebview.js",
     "start": {
-      "line": 41,
+      "line": 39,
       "column": 15
     },
     "end": {
-      "line": 44,
+      "line": 42,
       "column": 3
     }
   }

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -4,9 +4,9 @@ import { webContents } from '@electron/remote';
 import normalizeUrl from 'normalize-url';
 import path from 'path';
 
-import userAgent, { isChromeless } from '../helpers/userAgent-helpers';
 import { TODOS_RECIPE_ID, todosStore } from '../features/todos';
 import { isValidExternalURL } from '../helpers/url-helpers';
+import UserAgent from './UserAgent';
 
 const debug = require('debug')('Ferdi:Service');
 
@@ -94,7 +94,7 @@ export default class Service {
 
   @observable lostRecipeReloadAttempt = 0;
 
-  @observable chromelessUserAgent = false;
+  @observable userAgentModel = null;
 
   constructor(data, recipe) {
     if (!data) {
@@ -155,6 +155,8 @@ export default class Service {
     if (hibernate && hibernateOnStartup && !isActive) {
       this.isHibernating = true;
     }
+
+    this.userAgentModel = new UserAgent(recipe.overrideUserAgent);
 
     autorun(() => {
       if (!this.isEnabled) {
@@ -234,12 +236,7 @@ export default class Service {
   }
 
   @computed get userAgent() {
-    let ua = userAgent(this.chromelessUserAgent);
-    if (typeof this.recipe.overrideUserAgent === 'function') {
-      ua = this.recipe.overrideUserAgent();
-    }
-
-    return ua;
+    return this.userAgentModel.userAgent;
   }
 
   @computed get partition() {
@@ -249,6 +246,8 @@ export default class Service {
 
   initializeWebViewEvents({ handleIPCMessage, openWindow, stores }) {
     const webviewWebContents = webContents.fromId(this.webview.getWebContentsId());
+
+    this.userAgentModel.setWebviewReference(this.webview);
 
     // If the recipe has implemented modifyRequestHeaders,
     // Send those headers to ipcMain so that it can be set in session
@@ -262,23 +261,6 @@ export default class Service {
     } else {
       debug(this.name, 'modifyRequestHeaders is not defined in the recipe');
     }
-
-    const handleUserAgent = (url, forwardingHack = false) => {
-      if (isChromeless(url)) {
-        if (!this.chromelessUserAgent) {
-          debug('Setting user agent to chromeless for url', url);
-          this.webview.setUserAgent(userAgent(true));
-          if (forwardingHack) {
-            this.webview.loadURL(url);
-          }
-          this.chromelessUserAgent = true;
-        }
-      } else if (this.chromelessUserAgent) {
-        debug('Setting user agent to contain chrome');
-        this.webview.setUserAgent(this.userAgent);
-        this.chromelessUserAgent = false;
-      }
-    };
 
     this.webview.addEventListener('ipc-message', e => handleIPCMessage({
       serviceId: this.id,
@@ -306,8 +288,6 @@ export default class Service {
       }
     });
 
-    this.webview.addEventListener('will-navigate', event => handleUserAgent(event.url, true));
-
     this.webview.addEventListener('did-start-loading', (event) => {
       debug('Did start load', this.name, event);
 
@@ -325,10 +305,7 @@ export default class Service {
     };
 
     this.webview.addEventListener('did-frame-finish-load', didLoad.bind(this));
-    this.webview.addEventListener('did-navigate', (event) => {
-      handleUserAgent(event.url);
-      didLoad();
-    });
+    this.webview.addEventListener('did-navigate', didLoad.bind(this));
 
     this.webview.addEventListener('did-fail-load', (event) => {
       debug('Service failed to load', this.name, event);

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -4,7 +4,7 @@ import { webContents } from '@electron/remote';
 import normalizeUrl from 'normalize-url';
 import path from 'path';
 
-import userAgent from '../helpers/userAgent-helpers';
+import userAgent, { isChromeless } from '../helpers/userAgent-helpers';
 import { TODOS_RECIPE_ID, todosStore } from '../features/todos';
 import { isValidExternalURL } from '../helpers/url-helpers';
 
@@ -264,7 +264,7 @@ export default class Service {
     }
 
     const handleUserAgent = (url, forwardingHack = false) => {
-      if (url.startsWith('https://accounts.google.com')) {
+      if (isChromeless(url)) {
         if (!this.chromelessUserAgent) {
           debug('Setting user agent to chromeless for url', url);
           this.webview.setUserAgent(userAgent(true));

--- a/src/models/UserAgent.js
+++ b/src/models/UserAgent.js
@@ -1,0 +1,80 @@
+import {
+  action,
+  computed,
+  observe,
+  observable,
+} from 'mobx';
+
+import defaultUserAgent, { isChromeless } from '../helpers/userAgent-helpers';
+
+const debug = require('debug')('Ferdi:UserAgent');
+
+export default class UserAgent {
+  _willNavigateListener = null;
+
+  _didNavigateListener = null;
+
+  @observable.ref webview = null;
+
+  @observable chromelessUserAgent = false;
+
+  @observable getUserAgent = defaultUserAgent;
+
+  constructor(overrideUserAgent = null) {
+    if (typeof overrideUserAgent === 'function') {
+      this.getUserAgent = overrideUserAgent;
+    }
+
+    observe(this, 'webview', (change) => {
+      const { oldValue, newValue } = change;
+      if (oldValue !== null) {
+        this._removeWebviewEvents(oldValue);
+      }
+      if (newValue !== null) {
+        this._addWebviewEvents(newValue);
+      }
+    });
+  }
+
+  @computed get userAgent() {
+    return this.chromelessUserAgent ? defaultUserAgent(true) : this.getUserAgent();
+  }
+
+  @action setWebviewReference(webview) {
+    this.webview = webview;
+  }
+
+  @action _handleNavigate(url, forwardingHack = false) {
+    if (isChromeless(url)) {
+      if (!this.chromelessUserAgent) {
+        debug('Setting user agent to chromeless for url', url);
+        this.chromelessUserAgent = true;
+        this.webview.userAgent = this.userAgent;
+        if (forwardingHack) {
+          this.webview.loadURL(url);
+        }
+      }
+    } else if (this.chromelessUserAgent) {
+      debug('Setting user agent to contain chrome for url', url);
+      this.chromelessUserAgent = false;
+      this.webview.userAgent = this.userAgent;
+    }
+  }
+
+  _addWebviewEvents(webview) {
+    debug('Adding event handlers');
+
+    this._willNavigateListener = event => this._handleNavigate(event.url, true);
+    webview.addEventListener('will-navigate', this._willNavigateListener);
+
+    this._didNavigateListener = event => this._handleNavigate(event.url);
+    webview.addEventListener('did-navigate', this._didNavigateListener);
+  }
+
+  _removeWebviewEvents(webview) {
+    debug('Removing event handlers');
+
+    webview.removeEventListener('will-navigate', this._willNavigateListener);
+    webview.removeEventListener('did-navigate', this._didNavigateListener);
+  }
+}


### PR DESCRIPTION
### Description
The TickTick todo service fails to load if the Chrome version number does not appear in the User-Agent string. However, login to Google Tasks is prevented by the same.

We adopt the "chromeless" User-Agent logic from the service webview, which selectively exposes the Chrome version everywhere except the Google login screen. The common logic was moved into the userAgent-helpers module.

### Motivation and Context
Fixes #1211 

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally