### PR TITLE
Fix nightlies as pre-release candidates

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -16,9 +16,9 @@ mac:
   entitlementsInherit: "./build-helpers/entitlements.mas.inherit.plist"
   target:
     - target: dmg
-      arch:
-        - x64
-        - arm64
+      arch: [x64, arm64]
+    - target: zip
+      arch: [x64, arm64]
   extendInfo:
     NSCameraUsageDescription: "This app requires camera access for video chats"
     NSMicrophoneUsageDescription: "This app requires microphone access for voice chats"

--- a/src/electron/ipc-api/autoUpdate.js
+++ b/src/electron/ipc-api/autoUpdate.js
@@ -18,6 +18,7 @@ export default (params) => {
           autoUpdater.allowPrerelease = Boolean(params.settings.app.get('beta'));
 
           if (params.settings.app.get('nightly')) {
+            autoUpdater.allowPrerelease = Boolean(params.settings.app.get('nightly'));
             autoUpdater.setFeedURL({
               provider: 'github',
               repo: 'nightlies',


### PR DESCRIPTION
### Description
Fixes in-app updates to nightlies channel. This will also add creation of `zip` files into the uploaded artifacts due to [these notes](https://www.electron.build/auto-update#quick-setup-guide).

### Motivation and Context
Nightly builds are working, but the in-app updater is broken.

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally