### PR TITLE
Fix active Todos service behaviour

### DIFF
--- a/src/components/services/content/Services.js
+++ b/src/components/services/content/Services.js
@@ -10,7 +10,7 @@ import injectSheet from 'react-jss';
 import ServiceView from './ServiceView';
 import Appear from '../../ui/effects/Appear';
 import serverlessLogin from '../../../helpers/serverless-helpers';
-import { TODOS_RECIPE_ID } from '../../../features/todos';
+import { TODOS_RECIPES_ID } from '../../../config';
 
 const messages = defineMessages({
   welcome: {
@@ -171,7 +171,7 @@ export default @injectSheet(styles) @inject('actions') @observer class Services 
             </div>
           </Appear>
         )}
-        {services.filter(service => service.recipe.id !== TODOS_RECIPE_ID).map(service => (
+        {services.filter(service => service.recipe.id !== TODOS_RECIPES_ID[window.ferdi.stores.settings.all.app.predefinedTodoServer]).map(service => (
           <ServiceView
             key={service.id}
             service={service}

--- a/src/components/services/content/Services.js
+++ b/src/components/services/content/Services.js
@@ -10,7 +10,6 @@ import injectSheet from 'react-jss';
 import ServiceView from './ServiceView';
 import Appear from '../../ui/effects/Appear';
 import serverlessLogin from '../../../helpers/serverless-helpers';
-import { TODOS_RECIPES_ID } from '../../../config';
 
 const messages = defineMessages({
   welcome: {
@@ -171,7 +170,7 @@ export default @injectSheet(styles) @inject('actions') @observer class Services 
             </div>
           </Appear>
         )}
-        {services.filter(service => service.recipe.id !== TODOS_RECIPES_ID[window.ferdi.stores.settings.all.app.predefinedTodoServer]).map(service => (
+        {services.filter(service => !service.isTodosService).map(service => (
           <ServiceView
             key={service.id}
             service={service}

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -389,11 +389,9 @@ export default @observer class EditSettingsForm extends Component {
                         )}
                       </div>
                     )}
+                    <Hr />
                   </>
                 )}
-
-
-                <Hr />
 
                 <Toggle field={form.$('scheduledDNDEnabled')} />
                 {scheduledDNDEnabled && (

--- a/src/config.js
+++ b/src/config.js
@@ -61,10 +61,12 @@ export const SEARCH_ENGINE_URLS = {
   [SEARCH_ENGINE_DDG]: ({ searchTerm }) => `https://duckduckgo.com/?q=${searchTerm}`,
 };
 
-export const TODOS_RECIPES_ID = {
+export const CUSTOM_TODO_SERVICE = 'isUsingCustomTodoService';
+
+export const TODO_SERVICE_RECIPE_IDS = {
   'https://todoist.com/app': 'todoist',
   'https://app.franztodos.com': 'franz-todos',
-  'https://ticktick.com/signin': 'ticktick',
+  'https://ticktick.com/signin': 'TickTick',
   'https://todo.microsoft.com/?app#': 'mstodo',
   'https://habitica.com/login': 'habitica',
   'https://desktop.any.do/': 'anydo',
@@ -80,8 +82,12 @@ export const TODO_APPS = {
   'https://www.rememberthemilk.com/login/': 'Remember The Milk',
   'https://desktop.any.do/': 'Any.do',
   'https://tasks.google.com/embed/?origin=https%3A%2F%2Fcalendar.google.com&fullWidth=1': 'Google Tasks',
-  isUsingCustomTodoService: 'Other service',
+  [CUSTOM_TODO_SERVICE]: 'Other service',
 };
+
+export const DEFAULT_TODO_SERVICE = 'https://app.franztodos.com';
+export const DEFAULT_TODO_RECIPE_ID = TODO_SERVICE_RECIPE_IDS[DEFAULT_TODO_SERVICE];
+export const DEFAULT_TODO_SERVICE_NAME = TODO_APPS[DEFAULT_TODO_SERVICE];
 
 export const SIDEBAR_WIDTH = {
   35: 'Extremely slim sidebar',
@@ -130,7 +136,7 @@ export const DEFAULT_APP_SETTINGS = {
 
   // Ferdi specific options
   server: LIVE_API,
-  predefinedTodoServer: 'https://app.franztodos.com',
+  predefinedTodoServer: DEFAULT_TODO_SERVICE,
   autohideMenuBar: false,
   lockingFeatureEnabled: false,
   locked: false,

--- a/src/config.js
+++ b/src/config.js
@@ -61,6 +61,10 @@ export const SEARCH_ENGINE_URLS = {
   [SEARCH_ENGINE_DDG]: ({ searchTerm }) => `https://duckduckgo.com/?q=${searchTerm}`,
 };
 
+export const TODOS_RECIPES_ID = {
+  'https://todoist.com/app': 'todoist',
+};
+
 export const TODO_APPS = {
   'https://todoist.com/app': 'Todoist',
   'https://app.franztodos.com': 'Franz Todo',

--- a/src/config.js
+++ b/src/config.js
@@ -63,6 +63,11 @@ export const SEARCH_ENGINE_URLS = {
 
 export const TODOS_RECIPES_ID = {
   'https://todoist.com/app': 'todoist',
+  'https://app.franztodos.com': 'franz-todos',
+  'https://ticktick.com/signin': 'ticktick',
+  'https://todo.microsoft.com/?app#': 'mstodo',
+  'https://habitica.com/login': 'habitica',
+  'https://desktop.any.do/': 'anydo',
 };
 
 export const TODO_APPS = {

--- a/src/config.js
+++ b/src/config.js
@@ -63,29 +63,39 @@ export const SEARCH_ENGINE_URLS = {
 
 export const CUSTOM_TODO_SERVICE = 'isUsingCustomTodoService';
 
+const TODO_TODOIST_URL = 'https://todoist.com/app';
+const TODO_FRANZ_TODOS_URL = 'https://app.franztodos.com';
+const TODO_TICKTICK_URL = 'https://ticktick.com/signin';
+const TODO_MSTODO_URL = 'https://todo.microsoft.com/?app#';
+const TODO_HABITICA_URL = 'https://habitica.com/login';
+const TODO_NOZBE_URL = 'https://app.nozbe.com/#login';
+const TODO_RTM_URL = 'https://www.rememberthemilk.com/login/';
+const TODO_ANYDO_URL = 'https://desktop.any.do/';
+const TODO_GOOGLETASKS_URL = 'https://tasks.google.com/embed/?origin=https%3A%2F%2Fcalendar.google.com&fullWidth=1';
+
 export const TODO_SERVICE_RECIPE_IDS = {
-  'https://todoist.com/app': 'todoist',
-  'https://app.franztodos.com': 'franz-todos',
-  'https://ticktick.com/signin': 'TickTick',
-  'https://todo.microsoft.com/?app#': 'mstodo',
-  'https://habitica.com/login': 'habitica',
-  'https://desktop.any.do/': 'anydo',
+  [TODO_TODOIST_URL]: 'todoist',
+  [TODO_FRANZ_TODOS_URL]: 'franz-todos',
+  [TODO_TICKTICK_URL]: 'TickTick',
+  [TODO_MSTODO_URL]: 'mstodo',
+  [TODO_HABITICA_URL]: 'habitica',
+  [TODO_ANYDO_URL]: 'anydo',
 };
 
 export const TODO_APPS = {
-  'https://todoist.com/app': 'Todoist',
-  'https://app.franztodos.com': 'Franz Todo',
-  'https://ticktick.com/signin': 'TickTick',
-  'https://todo.microsoft.com/?app#': 'Microsoft To Do',
-  'https://habitica.com/login': 'Habitica',
-  'https://app.nozbe.com/#login': 'Nozbe',
-  'https://www.rememberthemilk.com/login/': 'Remember The Milk',
-  'https://desktop.any.do/': 'Any.do',
-  'https://tasks.google.com/embed/?origin=https%3A%2F%2Fcalendar.google.com&fullWidth=1': 'Google Tasks',
+  [TODO_TODOIST_URL]: 'Todoist',
+  [TODO_FRANZ_TODOS_URL]: 'Franz Todo',
+  [TODO_TICKTICK_URL]: 'TickTick',
+  [TODO_MSTODO_URL]: 'Microsoft To Do',
+  [TODO_HABITICA_URL]: 'Habitica',
+  [TODO_NOZBE_URL]: 'Nozbe',
+  [TODO_RTM_URL]: 'Remember The Milk',
+  [TODO_ANYDO_URL]: 'Any.do',
+  [TODO_GOOGLETASKS_URL]: 'Google Tasks',
   [CUSTOM_TODO_SERVICE]: 'Other service',
 };
 
-export const DEFAULT_TODO_SERVICE = 'https://app.franztodos.com';
+export const DEFAULT_TODO_SERVICE = TODO_FRANZ_TODOS_URL;
 export const DEFAULT_TODO_RECIPE_ID = TODO_SERVICE_RECIPE_IDS[DEFAULT_TODO_SERVICE];
 export const DEFAULT_TODO_SERVICE_NAME = TODO_APPS[DEFAULT_TODO_SERVICE];
 

--- a/src/containers/auth/SetupAssistantScreen.js
+++ b/src/containers/auth/SetupAssistantScreen.js
@@ -3,11 +3,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { inject, observer } from 'mobx-react';
 
+import { DEFAULT_TODO_RECIPE_ID, DEFAULT_TODO_SERVICE_NAME } from '../../config';
 import { sleep } from '../../helpers/async-helpers';
 import SetupAssistant from '../../components/auth/SetupAssistant';
 import ServicesStore from '../../stores/ServicesStore';
 import RecipesStore from '../../stores/RecipesStore';
-import { TODOS_RECIPE_ID } from '../../features/todos';
 import UserStore from '../../stores/UserStore';
 
 export default @inject('stores', 'actions') @observer class SetupAssistantScreen extends Component {
@@ -82,11 +82,11 @@ export default @inject('stores', 'actions') @observer class SetupAssistantScreen
       await sleep(100);
     }
 
-    // Add Franz ToDos
+    // Add todo service
     await services._createService({
-      recipeId: TODOS_RECIPE_ID,
+      recipeId: DEFAULT_TODO_RECIPE_ID,
       serviceData: {
-        name: 'Franz ToDos',
+        name: DEFAULT_TODO_SERVICE_NAME,
       },
       redirect: false,
       skipCleanup: true,

--- a/src/features/appearance/index.js
+++ b/src/features/appearance/index.js
@@ -93,10 +93,10 @@ function generateServiceRibbonWidthStyle(widthStr, iconSizeStr, vertical) {
     }
   ` : `
     .sidebar {
-      width: ${width - 2}px !important;
+      width: ${width}px !important;
     }
     .tab-item {
-      width: ${width - 2}px !important;
+      width: ${width}px !important;
       height: ${width - 5 + iconSize}px !important;
     }
     .tab-item .tab-item__icon {
@@ -104,6 +104,9 @@ function generateServiceRibbonWidthStyle(widthStr, iconSizeStr, vertical) {
     }
     .sidebar__button {
       font-size: ${width / 3}px !important;
+    }
+    .todos__todos-panel--expanded {
+      width: calc(100% - ${300 + width}px) !important;
     }
   `;
 }
@@ -155,6 +158,10 @@ function generateVerticalStyle(widthStr, alwaysShowWorkspaces) {
 
   .workspaces-drawer {
     maring-top: -${sidebarWidthStr} !important;
+  }
+
+  .todos__todos-panel--expanded {
+    width: calc(100% - 300px) !important;
   }
   `;
 }

--- a/src/features/todos/components/TodosWebview.js
+++ b/src/features/todos/components/TodosWebview.js
@@ -230,10 +230,10 @@ class TodosWebview extends Component {
       isTodoUrlValid = validURL(todoUrl);
     }
 
-    const todosPanelStyle = {
-      width: isVisible ? width : 0,
-      borderLeftWidth: isVisible ? '1px' : 0,
-    };
+    let displayedWidth = isVisible ? width : 0;
+    if (isTodosServiceActive) {
+      displayedWidth = null;
+    }
 
     return (
       <div
@@ -241,7 +241,7 @@ class TodosWebview extends Component {
           [classes.root]: true,
           [classes.isTodosServiceActive]: isTodosServiceActive,
         })}
-        style={todosPanelStyle}
+        style={{ width: displayedWidth }}
         onMouseUp={() => this.stopResize()}
         ref={(node) => { this.node = node; }}
         id="todos-panel"

--- a/src/features/todos/components/TodosWebview.js
+++ b/src/features/todos/components/TodosWebview.js
@@ -61,6 +61,10 @@ const styles = theme => ({
     position: 'absolute',
     right: 0,
     zIndex: 0,
+    borderLeftWidth: 0,
+  },
+  hidden: {
+    borderLeftWidth: 0,
   },
 });
 
@@ -188,6 +192,8 @@ class TodosWebview extends Component {
         className={classnames({
           [classes.root]: true,
           [classes.isTodosServiceActive]: isTodosServiceActive,
+          'todos__todos-panel--expanded': isTodosServiceActive,
+          [classes.hidden]: !isVisible,
         })}
         style={{ width: displayedWidth }}
         onMouseUp={() => this.stopResize()}

--- a/src/features/todos/containers/TodosScreen.js
+++ b/src/features/todos/containers/TodosScreen.js
@@ -28,7 +28,8 @@ class TodosScreen extends Component {
           minWidth={TODOS_MIN_WIDTH}
           resize={width => todoActions.resize({ width })}
           userAgent={todosStore.userAgent}
-          isTodosIncludedInCurrentPlan
+          todoUrl={todosStore.todoUrl}
+          isTodoUrlValid={todosStore.isTodoUrlValid}
         />
       </ErrorBoundary>
     );

--- a/src/features/todos/index.js
+++ b/src/features/todos/index.js
@@ -9,7 +9,6 @@ export const DEFAULT_TODOS_WIDTH = 300;
 export const TODOS_MIN_WIDTH = 200;
 export const DEFAULT_TODOS_VISIBLE = true;
 export const DEFAULT_IS_FEATURE_ENABLED_BY_USER = true;
-export const TODOS_RECIPE_ID = 'franz-todos';
 export const TODOS_PARTITION_ID = 'persist:todos';
 
 export const TODOS_ROUTES = {

--- a/src/features/todos/store.js
+++ b/src/features/todos/store.js
@@ -8,6 +8,7 @@ import localStorage from 'mobx-localstorage';
 
 import { todoActions } from './actions';
 import { CUSTOM_TODO_SERVICE, TODO_SERVICE_RECIPE_IDS } from '../../config';
+import { isValidExternalURL } from '../../helpers/url-helpers';
 import { FeatureStore } from '../utils/FeatureStore';
 import { createReactions } from '../../stores/lib/Reaction';
 import { createActionBindings } from '../utils/ActionBinding';
@@ -20,19 +21,6 @@ import { state as delayAppState } from '../delayApp';
 import UserAgent from '../../models/UserAgent';
 
 const debug = require('debug')('Ferdi:feature:todos:store');
-
-// NOTE: https://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
-function validURL(str) {
-  let url;
-
-  try {
-    url = new URL(str);
-  } catch (_) {
-    return false;
-  }
-
-  return url.protocol === 'http:' || url.protocol === 'https:';
-}
 
 export default class TodoStore extends FeatureStore {
   @observable stores = null;
@@ -89,7 +77,7 @@ export default class TodoStore extends FeatureStore {
   }
 
   @computed get isTodoUrlValid() {
-    return !this.isUsingPredefinedTodoServer || validURL(this.todoUrl);
+    return !this.isUsingPredefinedTodoServer || isValidExternalURL(this.todoUrl);
   }
 
   @computed get todoRecipeId() {

--- a/src/helpers/url-helpers.js
+++ b/src/helpers/url-helpers.js
@@ -5,7 +5,12 @@ import { ALLOWED_PROTOCOLS } from '../config';
 const debug = require('debug')('Ferdi:Helpers:url');
 
 export function isValidExternalURL(url) {
-  const parsedUrl = new URL(url);
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (_) {
+    return false;
+  }
 
   const isAllowed = ALLOWED_PROTOCOLS.includes(parsedUrl.protocol);
 

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -1743,65 +1743,65 @@
         "defaultMessage": "!!!Welcome to Ferdi",
         "end": {
           "column": 3,
-          "line": 19
+          "line": 18
         },
         "file": "src/components/services/content/Services.js",
         "id": "services.welcome",
         "start": {
           "column": 11,
-          "line": 16
+          "line": 15
         }
       },
       {
         "defaultMessage": "!!!Get started",
         "end": {
           "column": 3,
-          "line": 23
+          "line": 22
         },
         "file": "src/components/services/content/Services.js",
         "id": "services.getStarted",
         "start": {
           "column": 14,
-          "line": 20
+          "line": 19
         }
       },
       {
         "defaultMessage": "!!!Please login to use Ferdi.",
         "end": {
           "column": 3,
-          "line": 27
+          "line": 26
         },
         "file": "src/components/services/content/Services.js",
         "id": "services.login",
         "start": {
           "column": 9,
-          "line": 24
+          "line": 23
         }
       },
       {
         "defaultMessage": "!!!Use Ferdi without an Account",
         "end": {
           "column": 3,
-          "line": 31
+          "line": 30
         },
         "file": "src/components/services/content/Services.js",
         "id": "services.serverless",
         "start": {
           "column": 14,
-          "line": 28
+          "line": 27
         }
       },
       {
         "defaultMessage": "!!!Optionally, you can change your Ferdi server by clicking the cog in the bottom left corner.",
         "end": {
           "column": 3,
-          "line": 35
+          "line": 34
         },
         "file": "src/components/services/content/Services.js",
         "id": "services.serverInfo",
         "start": {
           "column": 14,
-          "line": 32
+          "line": 31
         }
       }
     ],

--- a/src/i18n/messages/src/components/services/content/Services.json
+++ b/src/i18n/messages/src/components/services/content/Services.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Welcome to Ferdi",
     "file": "src/components/services/content/Services.js",
     "start": {
-      "line": 16,
+      "line": 15,
       "column": 11
     },
     "end": {
-      "line": 19,
+      "line": 18,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!Get started",
     "file": "src/components/services/content/Services.js",
     "start": {
-      "line": 20,
+      "line": 19,
       "column": 14
     },
     "end": {
-      "line": 23,
+      "line": 22,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Please login to use Ferdi.",
     "file": "src/components/services/content/Services.js",
     "start": {
-      "line": 24,
+      "line": 23,
       "column": 9
     },
     "end": {
-      "line": 27,
+      "line": 26,
       "column": 3
     }
   },
@@ -43,11 +43,11 @@
     "defaultMessage": "!!!Use Ferdi without an Account",
     "file": "src/components/services/content/Services.js",
     "start": {
-      "line": 28,
+      "line": 27,
       "column": 14
     },
     "end": {
-      "line": 31,
+      "line": 30,
       "column": 3
     }
   },
@@ -56,11 +56,11 @@
     "defaultMessage": "!!!Optionally, you can change your Ferdi server by clicking the cog in the bottom left corner.",
     "file": "src/components/services/content/Services.js",
     "start": {
-      "line": 32,
+      "line": 31,
       "column": 14
     },
     "end": {
-      "line": 35,
+      "line": 34,
       "column": 3
     }
   }

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -4,7 +4,8 @@ import { webContents } from '@electron/remote';
 import normalizeUrl from 'normalize-url';
 import path from 'path';
 
-import { TODOS_RECIPE_ID, todosStore } from '../features/todos';
+import { todosStore } from '../features/todos';
+import { TODOS_RECIPES_ID } from '../config';
 import { isValidExternalURL } from '../helpers/url-helpers';
 import UserAgent from './UserAgent';
 
@@ -185,7 +186,7 @@ export default class Service {
   }
 
   get webview() {
-    if (this.recipe.id === TODOS_RECIPE_ID) {
+    if (this.recipe.id === TODOS_RECIPES_ID[window.ferdi.stores.settings.all.app.predefinedTodoServer]) {
       return todosStore.webview;
     }
 

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -5,7 +5,6 @@ import normalizeUrl from 'normalize-url';
 import path from 'path';
 
 import { todosStore } from '../features/todos';
-import { TODOS_RECIPES_ID } from '../config';
 import { isValidExternalURL } from '../helpers/url-helpers';
 import UserAgent from './UserAgent';
 
@@ -185,8 +184,12 @@ export default class Service {
     };
   }
 
+  @computed get isTodosService() {
+    return this.recipe.id === todosStore.todoRecipeId;
+  }
+
   get webview() {
-    if (this.recipe.id === TODOS_RECIPES_ID[window.ferdi.stores.settings.all.app.predefinedTodoServer]) {
+    if (this.isTodosService) {
       return todosStore.webview;
     }
 
@@ -243,7 +246,6 @@ export default class Service {
   @computed get partition() {
     return this.recipe.partition || `persist:service-${this.id}`;
   }
-
 
   initializeWebViewEvents({ handleIPCMessage, openWindow, stores }) {
     const webviewWebContents = webContents.fromId(this.webview.getWebContentsId());

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -20,7 +20,7 @@ import { getRecipeDirectory, getDevRecipeDirectory } from '../helpers/recipe-hel
 import { workspaceStore } from '../features/workspaces';
 import { serviceLimitStore } from '../features/serviceLimit';
 import { RESTRICTION_TYPES } from '../models/Service';
-import { KEEP_WS_LOADED_USID, TODOS_RECIPES_ID } from '../config';
+import { KEEP_WS_LOADED_USID } from '../config';
 import { SPELLCHECKER_LOCALES } from '../i18n/languages';
 
 const debug = require('debug')('Ferdi:ServiceStore');
@@ -273,11 +273,11 @@ export default class ServicesStore extends Store {
   }
 
   @computed get isTodosServiceAdded() {
-    return this.allDisplayed.find(service => service.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer] && service.isEnabled) || false;
+    return this.allDisplayed.find(service => service.isTodosService && service.isEnabled) || false;
   }
 
   @computed get isTodosServiceActive() {
-    return this.active && this.active.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer];
+    return this.active && this.active.isTodosService;
   }
 
   one(id) {
@@ -478,7 +478,7 @@ export default class ServicesStore extends Store {
     this._awake({ serviceId: service.id });
     service.lastUsed = Date.now();
 
-    if (this.active.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer] && !this.stores.todos.settings.isFeatureEnabledByUser) {
+    if (this.isTodosServiceActive && !this.stores.todos.settings.isFeatureEnabledByUser) {
       this.actions.todos.toggleTodosFeatureVisibility();
     }
 
@@ -712,7 +712,7 @@ export default class ServicesStore extends Store {
     service.resetMessageCount();
     service.lostRecipeConnection = false;
 
-    if (service.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer]) {
+    if (service.isTodosService) {
       return this.actions.todos.reload();
     }
 
@@ -799,7 +799,7 @@ export default class ServicesStore extends Store {
 
   @action _openDevTools({ serviceId }) {
     const service = this.one(serviceId);
-    if (service.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer]) {
+    if (service.isTodosService) {
       this.actions.todos.openDevTools();
     } else {
       service.webview.openDevTools();

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -20,8 +20,7 @@ import { getRecipeDirectory, getDevRecipeDirectory } from '../helpers/recipe-hel
 import { workspaceStore } from '../features/workspaces';
 import { serviceLimitStore } from '../features/serviceLimit';
 import { RESTRICTION_TYPES } from '../models/Service';
-import { KEEP_WS_LOADED_USID } from '../config';
-import { TODOS_RECIPE_ID } from '../features/todos';
+import { KEEP_WS_LOADED_USID, TODOS_RECIPES_ID } from '../config';
 import { SPELLCHECKER_LOCALES } from '../i18n/languages';
 
 const debug = require('debug')('Ferdi:ServiceStore');
@@ -274,11 +273,11 @@ export default class ServicesStore extends Store {
   }
 
   @computed get isTodosServiceAdded() {
-    return this.allDisplayed.find(service => service.recipe.id === TODOS_RECIPE_ID && service.isEnabled) || false;
+    return this.allDisplayed.find(service => service.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer] && service.isEnabled) || false;
   }
 
   @computed get isTodosServiceActive() {
-    return this.active && this.active.recipe.id === TODOS_RECIPE_ID;
+    return this.active && this.active.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer];
   }
 
   one(id) {
@@ -479,7 +478,7 @@ export default class ServicesStore extends Store {
     this._awake({ serviceId: service.id });
     service.lastUsed = Date.now();
 
-    if (this.active.recipe.id === TODOS_RECIPE_ID && !this.stores.todos.settings.isFeatureEnabledByUser) {
+    if (this.active.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer] && !this.stores.todos.settings.isFeatureEnabledByUser) {
       this.actions.todos.toggleTodosFeatureVisibility();
     }
 
@@ -713,7 +712,7 @@ export default class ServicesStore extends Store {
     service.resetMessageCount();
     service.lostRecipeConnection = false;
 
-    if (service.recipe.id === TODOS_RECIPE_ID) {
+    if (service.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer]) {
       return this.actions.todos.reload();
     }
 
@@ -800,7 +799,7 @@ export default class ServicesStore extends Store {
 
   @action _openDevTools({ serviceId }) {
     const service = this.one(serviceId);
-    if (service.recipe.id === TODOS_RECIPE_ID) {
+    if (service.recipe.id === TODOS_RECIPES_ID[this.stores.settings.all.app.predefinedTodoServer]) {
       this.actions.todos.openDevTools();
     } else {
       service.webview.openDevTools();

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -274,7 +274,7 @@ export default class ServicesStore extends Store {
   }
 
   @computed get isTodosServiceAdded() {
-    return this.allDisplayed.find(service => service.recipe.id === TODOS_RECIPE_ID && service.isEnabled) || null;
+    return this.allDisplayed.find(service => service.recipe.id === TODOS_RECIPE_ID && service.isEnabled) || false;
   }
 
   @computed get isTodosServiceActive() {


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
<!-- Describe your changes in detail. -->
Franz 5.6.0 came with a new behaviour related to Franz Todos. If a user adds Franz Todos as a service and uses Franz Todos simultaneously, the TodosWebView gets expended when the user switches to the Franz Todos service.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
For https://github.com/getferdi/ferdi/issues/1017#issuecomment-775014033.  

Ferdi offering multiple alternatives to Franz Todos, this pull request aim at maintaining this behaviour for the supported alternatives.

### Screenshots
<!-- Remove the section if this does not apply. -->

<img width="912" alt="Screen Shot 2021-06-03 at 12 12 42 AM" src="https://user-images.githubusercontent.com/412895/120558894-0b128180-c3f8-11eb-9316-85a0033b582b.png">

<img width="912" alt="Screen Shot 2021-06-03 at 12 12 55 AM" src="https://user-images.githubusercontent.com/412895/120558909-11a0f900-c3f8-11eb-912f-e51fb773d3ad.png">

https://user-images.githubusercontent.com/412895/120563873-8af11980-c401-11eb-86aa-1e97dac00f03.mp4

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally