### PR TITLE
Open external links in web browser by default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -438,14 +438,12 @@ ipcMain.on('feature-basic-auth-credentials', (e, { user, password }) => {
   authCallback = noop;
 });
 
-ipcMain.on('open-browser-window', (e, { disposition, url, serviceId }) => {
-  if (disposition === 'foreground-tab') {
-    const serviceSession = session.fromPartition(`persist:service-${serviceId}`);
-    const child = new BrowserWindow({ parent: mainWindow, webPreferences: { session: serviceSession } });
-    child.show();
-    child.loadURL(url);
-  }
-  debug('Received open-browser-window', disposition, url);
+ipcMain.on('open-browser-window', (e, { url, serviceId }) => {
+  const serviceSession = session.fromPartition(`persist:service-${serviceId}`);
+  const child = new BrowserWindow({ parent: mainWindow, webPreferences: { session: serviceSession } });
+  child.show();
+  child.loadURL(url);
+  debug('Received open-browser-window', url);
 });
 
 ipcMain.on('modifyRequestHeaders', (e, { modifiedRequestHeaders, serviceId }) => {

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -291,22 +291,20 @@ export default class Service {
       if (!isValidExternalURL(event.url)) {
         return;
       }
-      if (event.disposition === 'foreground-tab') {
-        ipcRenderer.send('open-browser-window', {
-          disposition: event.disposition,
-          url: event.url,
-          serviceId: this.id,
-        });
-      } else {
+      if (event.disposition === 'foreground-tab' || event.disposition === 'background-tab') {
         openWindow({
           event,
           url,
           frameName,
           options,
         });
+      } else {
+        ipcRenderer.send('open-browser-window', {
+          url: event.url,
+          serviceId: this.id,
+        });
       }
     });
-
 
     this.webview.addEventListener('will-navigate', event => handleUserAgent(event.url, true));
 


### PR DESCRIPTION
### Description
This PR slightly changes the behavior when clicking links. Now `new-window` events with dispositions `background-tab` and `foreground-tab` will open links in the default browser while those with `new-window` actually cause a new ferdi popup to open. So left clicking an external link will open in the browser by default.

I tested these changes on Windows 10 20H2 with the Gmail, Telegram, WhatsApp and Discord services.

### Motivation and Context
After reading through the referenced issues in #1474 I feel like most people expect clicking an external link to open in the default web browser rather than a ferdi popup window.

If this is not the intended behavior feel free to close this PR.

Also if there are different opinions regarding this it might be worth thinking about adding a setting to toggle the behavior.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally