### PR TITLE
Upgraded electron to '13.1.1'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14964,9 +14964,9 @@
       }
     },
     "electron": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.0.tgz",
-      "integrity": "sha512-ykRAaPWrVQkm2Lju4O4rMQzahNcxWLeLMrhBw8WnmIiugkvUH0MhZ85jsOTrAoQ2Zl1FC542bloKFWGSkeVjkg==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.1.tgz",
+      "integrity": "sha512-kySSb5CbIkWU2Kd9mf2rpGZC9p1nWhVVNl+CJjuOUGeVPXHbojHvTkDU1iC8AvV28eik3gqHisSJss40Caprog==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cross-env": "^5.0.5",
     "cz-conventional-changelog": "^2.1.0",
     "dotenv": "8.6.0",
-    "electron": "13.1.0",
+    "electron": "13.1.1",
     "electron-builder": "22.11.3",
     "electron-notarize": "1.0.0",
     "electron-rebuild": "2.3.5",


### PR DESCRIPTION
### Description
Upgrades electron to `13.1.1`

### Motivation and Context
Fixes crashes on latest gen Intel and Ryzen processors

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally