### PR TITLE
Skip notarization of the build artifact if not building for the main repo (ie building on a forked repo).

### DIFF
--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -107,6 +107,7 @@ jobs:
           echo "ELECTRON_CACHE=$HOME/.cache/electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
           echo "FORCE_REBUILD_ON_NIGHTLY=${{ contains(github.event.inputs.message, 'force build') && contains(github.event.inputs.message, 'nightly branch') }}" >> $GITHUB_ENV
+          echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
       - name: Set env vars for Windows
         if: startsWith(runner.os, 'Windows')
         run: |
@@ -115,6 +116,7 @@ jobs:
           echo "ELECTRON_CACHE=$USERPROFILE\.cache\electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$USERPROFILE\.cache\electron-builder" >> $GITHUB_ENV
           echo "FORCE_REBUILD_ON_NIGHTLY=${{ contains(github.event.inputs.message, 'force build') && contains(github.event.inputs.message, 'nightly branch') }}" >> $GITHUB_ENV
+          echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
         shell: bash
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled' or this is a forced rebuild on the nightly branch
         uses: actions/checkout@v2

--- a/build-helpers/notarize.js
+++ b/build-helpers/notarize.js
@@ -1,18 +1,18 @@
-const { notarize } = require("electron-notarize");
+const { notarize } = require('electron-notarize');
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context;
-  if (electronPlatformName !== "darwin" || (process.env.GIT_BRANCH_NAME !== 'release' && process.env.GIT_BRANCH_NAME !== 'nightly')) {
+  if (electronPlatformName !== 'darwin' || process.env.SKIP_NOTARIZATION === 'true' || (process.env.GIT_BRANCH_NAME !== 'release' && process.env.GIT_BRANCH_NAME !== 'nightly')) {
     return;
   }
 
   const appName = context.packager.appInfo.productFilename;
 
-  return await notarize({
-    appBundleId: "com.kytwb.ferdi",
+  await notarize({
+    appBundleId: 'com.kytwb.ferdi',
     appPath: `${appOutDir}/${appName}.app`,
-    ascProvider: "B6J9X9DWFL",
+    ascProvider: 'B6J9X9DWFL',
     appleId: process.env.APPLEID,
-    appleIdPassword: process.env.APPLEID_PASSWORD
+    appleIdPassword: process.env.APPLEID_PASSWORD,
   });
 };


### PR DESCRIPTION
### Description
Adds ability to skip the notarization step if building for a forked repo.

### Motivation and Context
I would like to build and publish into my own fork of the `nightlies` repo - so as to test that the nightly process is working fine. But, the build fails due to the absence of the signing keys from Apple. Since this is only for internal (ie contributors) testing, imo this is ok. For the main `getferdi` repo-owner, this is not skipped.

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally