### PR TITLE
Added new message when the user doesn't find a service

### DIFF
--- a/src/components/settings/recipes/RecipesDashboard.js
+++ b/src/components/settings/recipes/RecipesDashboard.js
@@ -40,7 +40,7 @@ const messages = defineMessages({
   },
   nothingFound: {
     id: 'settings.recipes.nothingFound',
-    defaultMessage: '!!!Sorry, but no service matched your search term - but you can still probably add it using the "Custom Website" option:',
+    defaultMessage: '!!!Sorry, but no service matched your search term - but you can still probably add it using the "Custom Website" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.',
   },
   servicesSuccessfulAddedInfo: {
     id: 'settings.recipes.servicesSuccessfulAddedInfo',
@@ -265,7 +265,7 @@ export default @injectSheet(styles) @observer class RecipesDashboard extends Com
                       </span>
 
                       <p className="settings__empty-state-text">{intl.formatMessage(messages.nothingFound)}</p>
-                      
+
                       <RecipeItem
                         key={customWebsiteRecipe.id}
                         recipe={customWebsiteRecipe}

--- a/src/components/settings/services/ServicesDashboard.js
+++ b/src/components/settings/services/ServicesDashboard.js
@@ -27,7 +27,7 @@ const messages = defineMessages({
   },
   noServiceFound: {
     id: 'settings.recipes.nothingFound',
-    defaultMessage: '!!!Sorry, but no service matched your search term.',
+    defaultMessage: '!!!Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.',
   },
   discoverServices: {
     id: 'settings.services.discoverServices',

--- a/src/i18n/locales/af.json
+++ b/src/i18n/locales/af.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/ar.json
+++ b/src/i18n/locales/ar.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "الخدمات المتاحة",
   "settings.recipes.missingService": "خدمة مفقودة؟",
   "settings.recipes.mostPopular": "الأكثر شعبية",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "تمت إضافة الخدمة بنجاح",
   "settings.searchService": "البحث عن خدمة",
   "settings.service.error.goBack": "العودة إلى الخدمات",

--- a/src/i18n/locales/be.json
+++ b/src/i18n/locales/be.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/bs.json
+++ b/src/i18n/locales/bs.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Serveis disponibles",
   "settings.recipes.missingService": "Trobes a faltar algun servei?",
   "settings.recipes.mostPopular": "Els més populars",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "El servei s'ha afegit correctament",
   "settings.searchService": "Cercar servei",
   "settings.service.error.goBack": "Tornar als serveis",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Dostupné služby",
   "settings.recipes.missingService": "Chybějící služba?",
   "settings.recipes.mostPopular": "Nejpopulárnější",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Služba byla úspěšně přidána",
   "settings.searchService": "Vyhledat službu",
   "settings.service.error.goBack": "Zpět na služby",

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -2524,7 +2524,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+        "defaultMessage": "!!!Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
         "end": {
           "column": 3,
           "line": 44
@@ -3155,7 +3155,7 @@
         }
       },
       {
-        "defaultMessage": "!!!Sorry, but no service matched your search term.",
+        "defaultMessage": "!!!Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
         "end": {
           "column": 3,
           "line": 31

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Διαθέσιμες υπηρεσίες",
   "settings.recipes.missingService": "Λείπει κάποια υπηρεσία;",
   "settings.recipes.mostPopular": "Τα πιο δημοφιλή",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Η υπηρεσία προστέθηκε με επιτυχία",
   "settings.searchService": "Αναζήτηση υπηρεσίας",
   "settings.service.error.goBack": "Επιστροφή στις υπηρεσίες",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/fil.json
+++ b/src/i18n/locales/fil.json
@@ -285,7 +285,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term.",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Seirbhísí le fáil",
   "settings.recipes.missingService": "Seirbhís ar iarraidh?",
   "settings.recipes.mostPopular": "Is coitianta",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Seirbhís curtha go rathúil",
   "settings.searchService": "Cuardaigh seirbhís",
   "settings.service.error.goBack": "Ar ais chuig seirbhísí",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Dostupne usluge",
   "settings.recipes.missingService": "Da li neki servis nedostaje?",
   "settings.recipes.mostPopular": "Najpopularniji",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Usluga uspješno dodana. ",
   "settings.searchService": "Potraži servis",
   "settings.service.error.goBack": "Nazad do servisa",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Elérhető szolgáltatások",
   "settings.recipes.missingService": "Hiányzik egy szolgáltatás?",
   "settings.recipes.mostPopular": "Legnépszerűbb",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Szolgáltatás sikeresen hozzáadva",
   "settings.searchService": "Szolgáltatások keresése",
   "settings.service.error.goBack": "Vissza a szolgáltatásokhoz",

--- a/src/i18n/locales/id.json
+++ b/src/i18n/locales/id.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Layanan tersedia",
   "settings.recipes.missingService": "Layanan tidak tersedia?",
   "settings.recipes.mostPopular": "Terpopuler",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Layanan berhasil ditambahkan",
   "settings.searchService": "Cari layanan",
   "settings.service.error.goBack": "Kembali ke layanan",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "利用可能なサービス",
   "settings.recipes.missingService": "使いたいサービスが一覧にありませんか?",
   "settings.recipes.mostPopular": "最も人気",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "サービスが追加されました",
   "settings.searchService": "サービスを検索",
   "settings.service.error.goBack": "サービスに戻る",

--- a/src/i18n/locales/ka.json
+++ b/src/i18n/locales/ka.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "ხელმისაწვდომი სერვისები",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "ყველაზე პოპულარული",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "სერვისი წარმატებით დაემატა",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "სერვისებში დაბრუნება",

--- a/src/i18n/locales/kk.json
+++ b/src/i18n/locales/kk.json
@@ -285,7 +285,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term.",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "사용가능 한 서비스",
   "settings.recipes.missingService": "서비스가 보이지 않습니까?",
   "settings.recipes.mostPopular": "가장 인기 있는",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "서비스가 성공적으로 추가되었습니다.",
   "settings.searchService": "서비스 찾기",
   "settings.service.error.goBack": "서비스로 돌아가기",

--- a/src/i18n/locales/ms.json
+++ b/src/i18n/locales/ms.json
@@ -285,7 +285,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term.",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/nl-BE.json
+++ b/src/i18n/locales/nl-BE.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Beschikbare services",
   "settings.recipes.missingService": "Mist er een service?",
   "settings.recipes.mostPopular": "Meest populair",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service succesvol toegevoegd",
   "settings.searchService": "Service zoeken",
   "settings.service.error.goBack": "Terug naar services",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Beschikbare services",
   "settings.recipes.missingService": "Mis je een service?",
   "settings.recipes.mostPopular": "Meest populair",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service succesvol toegevoegd",
   "settings.searchService": "Zoek service",
   "settings.service.error.goBack": "Terug naar services",

--- a/src/i18n/locales/no.json
+++ b/src/i18n/locales/no.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Tilgjengelige tjenester",
   "settings.recipes.missingService": "Mangler en tjeneste?",
   "settings.recipes.mostPopular": "Mest populære",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Tjenesten ble vellykket lagt til",
   "settings.searchService": "Søk etter tjeneste",
   "settings.service.error.goBack": "Tilbake til tjenester",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Dostępne usługi",
   "settings.recipes.missingService": "Brak usługi?",
   "settings.recipes.mostPopular": "Najpopularniejsze",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Usługa została dodana pomyślnie",
   "settings.searchService": "Wyszukaj usługę",
   "settings.service.error.goBack": "Wróć do usług",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Serviços disponíveis",
   "settings.recipes.missingService": "Sente falta de algum serviço?",
   "settings.recipes.mostPopular": "Mais populares",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Serviço adicionado com sucesso",
   "settings.searchService": "Procurar serviço",
   "settings.service.error.goBack": "Voltar aos serviços",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Доступные сервисы",
   "settings.recipes.missingService": "Не можете найти сервис?",
   "settings.recipes.mostPopular": "Самые популярные",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Сервис успешно добавлен",
   "settings.searchService": "Найти сервис",
   "settings.service.error.goBack": "Вернуться к сервисам",

--- a/src/i18n/locales/si.json
+++ b/src/i18n/locales/si.json
@@ -285,7 +285,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term.",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Dostupné služby",
   "settings.recipes.missingService": "Chýba vám služba?",
   "settings.recipes.mostPopular": "Najpopulárnejšie",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Služba bola úspešne pridaná",
   "settings.searchService": "Vyhľadať službu",
   "settings.service.error.goBack": "Späť na služby",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/sq.json
+++ b/src/i18n/locales/sq.json
@@ -285,7 +285,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term.",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/sr.json
+++ b/src/i18n/locales/sr.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Dostupne usluge",
   "settings.recipes.missingService": "Da li neki servis nedostaje?",
   "settings.recipes.mostPopular": "Najpopularniji",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Usluga uspješno dodana",
   "settings.searchService": "Претражи услуге",
   "settings.service.error.goBack": "Nazad do servisa",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Tillgängliga tjänster",
   "settings.recipes.missingService": "Saknar du en tjänst?",
   "settings.recipes.mostPopular": "Mest populära",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Tjänsten har lagts till",
   "settings.searchService": "Sök efter tjänst",
   "settings.service.error.goBack": "Tillbaka till tjänster",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Mevcut servisler",
   "settings.recipes.missingService": "Aradığın servisi bulamadın mı?",
   "settings.recipes.mostPopular": "En popüler",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Servis başarıyla eklendi",
   "settings.searchService": "Hizmeti ara",
   "settings.service.error.goBack": "Servislere geri dön",

--- a/src/i18n/locales/uk.json
+++ b/src/i18n/locales/uk.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Доступні сервіси",
   "settings.recipes.missingService": "Не знайшли сервісу?",
   "settings.recipes.mostPopular": "Найбільш популярні",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Сервіс успішно додано",
   "settings.searchService": "Знайти сервіс",
   "settings.service.error.goBack": "Повернутись до сервісів",

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Phổ biến nhất",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Tìm kiếm dịch vụ",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -345,7 +345,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term.",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/locales/zh-HANT.json
+++ b/src/i18n/locales/zh-HANT.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "可用服務",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "熱門",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "新增服務成功",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "返回",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -377,7 +377,7 @@
   "settings.recipes.headline": "Available services",
   "settings.recipes.missingService": "Missing a service?",
   "settings.recipes.mostPopular": "Most popular",
-  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+  "settings.recipes.nothingFound": "Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
   "settings.recipes.servicesSuccessfulAddedInfo": "Service successfully added",
   "settings.searchService": "Search service",
   "settings.service.error.goBack": "Back to services",

--- a/src/i18n/messages/src/components/settings/recipes/RecipesDashboard.json
+++ b/src/i18n/messages/src/components/settings/recipes/RecipesDashboard.json
@@ -66,7 +66,7 @@
   },
   {
     "id": "settings.recipes.nothingFound",
-    "defaultMessage": "!!!Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option:",
+    "defaultMessage": "!!!Sorry, but no service matched your search term - but you can still probably add it using the \"Custom Website\" option. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
     "file": "src/components/settings/recipes/RecipesDashboard.js",
     "start": {
       "line": 41,

--- a/src/i18n/messages/src/components/settings/services/ServicesDashboard.json
+++ b/src/i18n/messages/src/components/settings/services/ServicesDashboard.json
@@ -40,7 +40,7 @@
   },
   {
     "id": "settings.recipes.nothingFound",
-    "defaultMessage": "!!!Sorry, but no service matched your search term.",
+    "defaultMessage": "!!!Sorry, but no service matched your search term. Please note that the website might show more services that have been added to Ferdi since the version that you are currently on. To get those new services, please consider upgrading to a newer version of Ferdi.",
     "file": "src/components/settings/services/ServicesDashboard.js",
     "start": {
       "line": 28,

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -4,11 +4,11 @@
     "defaultMessage": "!!!Launch Ferdi on start",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 32,
+      "line": 31,
       "column": 21
     },
     "end": {
-      "line": 35,
+      "line": 34,
       "column": 3
     }
   },
@@ -17,11 +17,11 @@
     "defaultMessage": "!!!Open in background",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 36,
+      "line": 35,
       "column": 26
     },
     "end": {
-      "line": 39,
+      "line": 38,
       "column": 3
     }
   },
@@ -30,11 +30,11 @@
     "defaultMessage": "!!!Keep Ferdi in background when closing the window",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 40,
+      "line": 39,
       "column": 19
     },
     "end": {
-      "line": 43,
+      "line": 42,
       "column": 3
     }
   },
@@ -43,11 +43,11 @@
     "defaultMessage": "!!!Start minimized",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 44,
+      "line": 43,
       "column": 18
     },
     "end": {
-      "line": 47,
+      "line": 46,
       "column": 3
     }
   },
@@ -56,11 +56,11 @@
     "defaultMessage": "!!!Always show Ferdi in System Tray",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 48,
+      "line": 47,
       "column": 20
     },
     "end": {
-      "line": 51,
+      "line": 50,
       "column": 3
     }
   },
@@ -69,11 +69,11 @@
     "defaultMessage": "!!!Always show Ferdi in Menu Bar",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 52,
+      "line": 51,
       "column": 17
     },
     "end": {
-      "line": 55,
+      "line": 54,
       "column": 3
     }
   },
@@ -82,11 +82,11 @@
     "defaultMessage": "!!!Reload Ferdi after system resume",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 56,
+      "line": 55,
       "column": 21
     },
     "end": {
-      "line": 59,
+      "line": 58,
       "column": 3
     }
   },
@@ -95,11 +95,11 @@
     "defaultMessage": "!!!Minimize Ferdi to system tray",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 60,
+      "line": 59,
       "column": 24
     },
     "end": {
-      "line": 63,
+      "line": 62,
       "column": 3
     }
   },
@@ -108,11 +108,11 @@
     "defaultMessage": "!!!Close Ferdi to system tray",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 64,
+      "line": 63,
       "column": 21
     },
     "end": {
-      "line": 67,
+      "line": 66,
       "column": 3
     }
   },
@@ -121,11 +121,11 @@
     "defaultMessage": "!!!Don't show message content in notifications",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 68,
+      "line": 67,
       "column": 24
     },
     "end": {
-      "line": 71,
+      "line": 70,
       "column": 3
     }
   },
@@ -134,11 +134,11 @@
     "defaultMessage": "!!!Don't show notifications for clipboard events",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 72,
+      "line": 71,
       "column": 26
     },
     "end": {
-      "line": 75,
+      "line": 74,
       "column": 3
     }
   },
@@ -147,11 +147,11 @@
     "defaultMessage": "!!!Notify TaskBar/Dock on new message",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 76,
+      "line": 75,
       "column": 26
     },
     "end": {
-      "line": 79,
+      "line": 78,
       "column": 3
     }
   },
@@ -160,11 +160,11 @@
     "defaultMessage": "!!!Navigation bar behaviour",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 80,
+      "line": 79,
       "column": 26
     },
     "end": {
-      "line": 83,
+      "line": 82,
       "column": 3
     }
   },
@@ -173,11 +173,11 @@
     "defaultMessage": "!!!Search engine",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 84,
+      "line": 83,
       "column": 16
     },
     "end": {
-      "line": 87,
+      "line": 86,
       "column": 3
     }
   },
@@ -186,11 +186,11 @@
     "defaultMessage": "!!!Send telemetry data",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 88,
+      "line": 87,
       "column": 10
     },
     "end": {
-      "line": 91,
+      "line": 90,
       "column": 3
     }
   },
@@ -199,11 +199,11 @@
     "defaultMessage": "!!!Enable service hibernation",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 92,
+      "line": 91,
       "column": 13
     },
     "end": {
-      "line": 95,
+      "line": 94,
       "column": 3
     }
   },
@@ -212,11 +212,11 @@
     "defaultMessage": "!!!Keep services in hibernation on startup",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 96,
+      "line": 95,
       "column": 22
     },
     "end": {
-      "line": 99,
+      "line": 98,
       "column": 3
     }
   },
@@ -225,11 +225,11 @@
     "defaultMessage": "!!!Hibernation strategy",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 100,
+      "line": 99,
       "column": 23
     },
     "end": {
-      "line": 103,
+      "line": 102,
       "column": 3
     }
   },
@@ -238,11 +238,11 @@
     "defaultMessage": "!!!Todo Server",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 104,
+      "line": 103,
       "column": 24
     },
     "end": {
-      "line": 107,
+      "line": 106,
       "column": 3
     }
   },
@@ -251,11 +251,11 @@
     "defaultMessage": "!!!Custom TodoServer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 108,
+      "line": 107,
       "column": 20
     },
     "end": {
-      "line": 111,
+      "line": 110,
       "column": 3
     }
   },
@@ -264,11 +264,11 @@
     "defaultMessage": "!!!Enable Password Lock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 112,
+      "line": 111,
       "column": 14
     },
     "end": {
-      "line": 115,
+      "line": 114,
       "column": 3
     }
   },
@@ -277,11 +277,11 @@
     "defaultMessage": "!!!Password",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 116,
+      "line": 115,
       "column": 16
     },
     "end": {
-      "line": 119,
+      "line": 118,
       "column": 3
     }
   },
@@ -290,11 +290,11 @@
     "defaultMessage": "!!!Allow using Touch ID to unlock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 120,
+      "line": 119,
       "column": 22
     },
     "end": {
-      "line": 123,
+      "line": 122,
       "column": 3
     }
   },
@@ -303,11 +303,11 @@
     "defaultMessage": "!!!Lock after inactivity",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 124,
+      "line": 123,
       "column": 18
     },
     "end": {
-      "line": 127,
+      "line": 126,
       "column": 3
     }
   },
@@ -316,11 +316,11 @@
     "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 128,
+      "line": 127,
       "column": 23
     },
     "end": {
-      "line": 131,
+      "line": 130,
       "column": 3
     }
   },
@@ -329,11 +329,11 @@
     "defaultMessage": "!!!From",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 132,
+      "line": 131,
       "column": 21
     },
     "end": {
-      "line": 135,
+      "line": 134,
       "column": 3
     }
   },
@@ -342,11 +342,11 @@
     "defaultMessage": "!!!To",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 136,
+      "line": 135,
       "column": 19
     },
     "end": {
-      "line": 139,
+      "line": 138,
       "column": 3
     }
   },
@@ -355,11 +355,11 @@
     "defaultMessage": "!!!Language",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 140,
+      "line": 139,
       "column": 12
     },
     "end": {
-      "line": 143,
+      "line": 142,
       "column": 3
     }
   },
@@ -368,11 +368,11 @@
     "defaultMessage": "!!!Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 144,
+      "line": 143,
       "column": 12
     },
     "end": {
-      "line": 147,
+      "line": 146,
       "column": 3
     }
   },
@@ -381,11 +381,11 @@
     "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 148,
+      "line": 147,
       "column": 21
     },
     "end": {
-      "line": 151,
+      "line": 150,
       "column": 3
     }
   },
@@ -394,11 +394,11 @@
     "defaultMessage": "!!!Enable universal Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 152,
+      "line": 151,
       "column": 21
     },
     "end": {
-      "line": 155,
+      "line": 154,
       "column": 3
     }
   },
@@ -407,11 +407,11 @@
     "defaultMessage": "!!!Sidebar width",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 156,
+      "line": 155,
       "column": 22
     },
     "end": {
-      "line": 159,
+      "line": 158,
       "column": 3
     }
   },
@@ -420,11 +420,11 @@
     "defaultMessage": "!!!Service icon size",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 160,
+      "line": 159,
       "column": 12
     },
     "end": {
-      "line": 163,
+      "line": 162,
       "column": 3
     }
   },
@@ -433,11 +433,11 @@
     "defaultMessage": "!!!Use vertical style",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 164,
+      "line": 163,
       "column": 20
     },
     "end": {
-      "line": 167,
+      "line": 166,
       "column": 3
     }
   },
@@ -446,11 +446,11 @@
     "defaultMessage": "!!!Always show workspace drawer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 168,
+      "line": 167,
       "column": 24
     },
     "end": {
-      "line": 171,
+      "line": 170,
       "column": 3
     }
   },
@@ -459,11 +459,11 @@
     "defaultMessage": "!!!Accent color",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 172,
+      "line": 171,
       "column": 15
     },
     "end": {
-      "line": 175,
+      "line": 174,
       "column": 3
     }
   },
@@ -472,11 +472,11 @@
     "defaultMessage": "!!!Display disabled services tabs",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 176,
+      "line": 175,
       "column": 24
     },
     "end": {
-      "line": 179,
+      "line": 178,
       "column": 3
     }
   },
@@ -485,11 +485,11 @@
     "defaultMessage": "!!!Show unread message badge when notifications are disabled",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 180,
+      "line": 179,
       "column": 29
     },
     "end": {
-      "line": 183,
+      "line": 182,
       "column": 3
     }
   },
@@ -498,11 +498,11 @@
     "defaultMessage": "!!!Show draggable area on window",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 184,
+      "line": 183,
       "column": 16
     },
     "end": {
-      "line": 187,
+      "line": 186,
       "column": 3
     }
   },
@@ -511,11 +511,11 @@
     "defaultMessage": "!!!Enable spell checking",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 188,
+      "line": 187,
       "column": 23
     },
     "end": {
-      "line": 191,
+      "line": 190,
       "column": 3
     }
   },
@@ -524,11 +524,11 @@
     "defaultMessage": "!!!Enable GPU Acceleration",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 192,
+      "line": 191,
       "column": 25
     },
     "end": {
-      "line": 195,
+      "line": 194,
       "column": 3
     }
   },
@@ -537,11 +537,11 @@
     "defaultMessage": "!!!Include beta versions",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 196,
+      "line": 195,
       "column": 8
     },
     "end": {
-      "line": 199,
+      "line": 198,
       "column": 3
     }
   },
@@ -550,11 +550,11 @@
     "defaultMessage": "!!!Enable updates",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 200,
+      "line": 199,
       "column": 20
     },
     "end": {
-      "line": 203,
+      "line": 202,
       "column": 3
     }
   },
@@ -563,11 +563,11 @@
     "defaultMessage": "!!!Enable Franz Todos",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 204,
+      "line": 203,
       "column": 15
     },
     "end": {
-      "line": 207,
+      "line": 206,
       "column": 3
     }
   },
@@ -576,11 +576,11 @@
     "defaultMessage": "!!!Keep all workspaces loaded",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 208,
+      "line": 207,
       "column": 27
     },
     "end": {
-      "line": 211,
+      "line": 210,
       "column": 3
     }
   }


### PR DESCRIPTION
### Description
While searching for services within Ferdi, many users are unable to find the service - but, these services are shown in the website that Ferdi supports them! The basic gap is that, as soon as a service-recipe is added into the repository, they can show up in the `README.md` - but, a user who has Ferdi installed on their machine would not see these recipes. This PR adds a message prompting the user to upgrade their Ferdi installation.

### Motivation and Context
This idea/need came from [this comment](https://github.com/getferdi/recipes/issues/547#issuecomment-865180411).

### Screenshots
<img width="660" alt="Screen Shot 2021-06-23 at 4 20 05 PM" src="https://user-images.githubusercontent.com/69629/123084655-07927900-d43f-11eb-9d82-43851052ebaf.png">

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally