### PR TITLE
Enforce strict adherence to node, npm and node-gyp versions (mainly for contributors)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "npm": "^6.14",
     "node-gyp": "^8.0"
   },
+  "engine-strict": true,
   "scripts": {
     "prepare": "husky install",
     "prestart": "npm run rebuild",


### PR DESCRIPTION
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly e.g. "Add Google Tasks to Todo providers". -->

### Description
Enforce version numbers for `npm`, `node` and `node-gyp`.

### Motivation and Context
New contributors don't seem to follow the instructions - and raise tickets that code doesn't work. Though their involvement is welcomed, it still takes up valuable time (that already seem scarce) from contributors. Remotely debugging the causes, and finally realizing that the node or npm or other system dependencies are incorrect - is draining too much motivation. Using this setting to enforce will ensure that superfluous settings are caught earlier.

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally