### PR TITLE
Hoist packages with lerna - so that we can benefit from consistent versions

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@mdi/js": "^3.3.92",
     "@mdi/react": "^1.1.0",
-    "@meetfranz/theme": "^1.0.14",
+    "@meetfranz/theme": "file:../theme",
     "react-html-attributes": "^1.4.3",
     "react-loader": "2.4.7"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mdi/react": "^1.1.0",
-    "@meetfranz/theme": "^1.0.14",
+    "@meetfranz/theme": "file:../theme",
     "react-loader": "2.4.7"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Looking through the lerna documentation, it seems that we have been using the same packages, but with coincidentally the same version numbers. Instead, lerna provides a way to keep them bound tightly by using `file:...` mechanism. This PR enforces that rule. No other behavior change is introduced here.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally