### PR TITLE
Dependency updates, linter fixes - run in develop branch

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -42,10 +42,6 @@ jobs:
           npm i -g node-gyp@8.0.0 && npm config set node_gyp "$(which node-gyp)"
       - name: Install node dependencies recursively
         run: npx lerna bootstrap
-      - name: Setup git configs
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
       - name: Update submodules, dependencies and run tests
         run: |
           echo "Updating submodules"
@@ -59,5 +55,7 @@ jobs:
           npm run test
 
           echo "Committing and pushing submodules, dependency-updates and linter changes"
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git commit -am "Update submodules, browserslist data updates and linter fixes [skip ci]" --no-verify || true
           git push origin nightly --no-verify

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -1,0 +1,63 @@
+# This workflow will do a clean install of ferdi dev-dependencies, update the dependencies, build the source code and run tests. It will only run on scheduled trigger.
+
+name: Ferdi Dependency updates
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # every night at 12 am
+
+env:
+  USE_HARD_LINKS: false
+
+jobs:
+  dependency_updates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env vars
+        run: |
+          echo "NPM_CACHE=$HOME/.npm" >> $GITHUB_ENV
+      - name: Checkout code along with submodules
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ${{ env.NPM_CACHE }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Use Node.js 14.16.1
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14.16.1
+      - name: Uninstall locally and reinstall node-gyp globally
+        run: |
+          npm uninstall node-gyp
+          npm i -g node-gyp@8.0.0 && npm config set node_gyp "$(which node-gyp)"
+      - name: Install node dependencies recursively
+        run: npx lerna bootstrap
+      - name: Setup git configs
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Update submodules, dependencies and run tests
+        run: |
+          echo "Updating submodules"
+          git submodule update --remote -f
+
+          echo "Updating browserslist db"
+          npx browserslist@latest --update-db
+
+          echo "Running linter and tests"
+          npm run lint
+          npm run test
+
+          echo "Committing and pushing submodules, dependency-updates and linter changes"
+          git commit -am "Update submodules, browserslist data updates and linter fixes [skip ci]" --no-verify || true
+          git push origin nightly --no-verify

--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -37,12 +37,6 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - name: Set env vars
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        run: |
-          echo "NPM_CACHE=$HOME/.npm" >> $GITHUB_ENV
-          echo "ELECTRON_CACHE=$HOME/.cache/electron" >> $GITHUB_ENV
-          echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled'
         uses: actions/checkout@v2
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
@@ -50,66 +44,15 @@ jobs:
           ref: nightly
           submodules: recursive
           fetch-depth: 0
-      - name: Cache node modules
-        uses: actions/cache@v2
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ${{ env.NPM_CACHE }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - name: Cache electron modules
-        uses: actions/cache@v2
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        env:
-          cache-name: cache-electron-modules
-        with:
-          key: ${{ runner.os }}-${{ env.cache-name }}
-          path: ${{ env.ELECTRON_CACHE }}
-      - name: Cache electron-builder modules
-        uses: actions/cache@v2
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        env:
-          cache-name: cache-electron-builder-modules
-        with:
-          key: ${{ runner.os }}-${{ env.cache-name }}
-          path: ${{ env.ELECTRON_BUILDER_CACHE }}
-      - name: Use Node.js 14.16.1
-        uses: actions/setup-node@v2
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        with:
-          node-version: 14.16.1
-      - name: Uninstall locally and reinstall node-gyp globally
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        run: |
-          npm uninstall node-gyp
-          npm i -g node-gyp@8.0.0 && npm config set node_gyp "$(which node-gyp)"
-      - name: Install node dependencies recursively
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        run: npx lerna bootstrap
-      - name: Print latest commit
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        run: echo ${{ github.sha }}
-      - name: Setup git configs
+      - id: should_run
+        name: Check whether there are any commits since this run was last triggered and push them and/or set the output
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-      - name: Merge from 'origin/develop' (continue if errored)
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        continue-on-error: true
-        run: git merge --no-ff --no-verify --commit -m "Merge remote-tracking branch 'origin/develop' into HEAD" origin/develop
-      - id: should_run
-        name: Check whether there are any commits since this run was last triggered and either push or set the output
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        run: |
-          echo "Running linter and tests"
-          npm run lint && npm run test
-          git commit -am "Apply linter fixes" --no-verify || true
+
+          echo "Merge from 'origin/develop'"
+          git merge --no-ff --no-verify --commit -m "Merge remote-tracking branch 'origin/develop' into HEAD" origin/develop
 
           CHANGES_COUNT=$(git diff --shortstat origin/nightly | wc -l)
           MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"

--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -24,7 +24,7 @@ on:
         description: 'Message for build'
         required: true
   schedule:
-    - cron: '0 0 * * *' # every night at 12 am
+    - cron: '0 1 * * *' # every night at 1 am (to allow for dependency builds to complete)
 
 env:
   USE_HARD_LINKS: false
@@ -103,25 +103,14 @@ jobs:
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
         continue-on-error: true
         run: git merge --no-ff --no-verify --commit -m "Merge remote-tracking branch 'origin/develop' into HEAD" origin/develop
-      - name: Update submodules (continue if errored)
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
-        continue-on-error: true
-        run: |
-          echo "Updating submodules"
-          git submodule update --remote -f
-          git commit -am "Update submodules" --no-verify || true
-
-          echo "Running linter and tests"
-          npm run lint && npm run test
-          git commit -am "Apply linter fixes" --no-verify || true
-
-          echo "Updating browserslist db"
-          npx browserslist@latest --update-db
-          git commit -am "Apply browserslist data updates" --no-verify || true
       - id: should_run
         name: Check whether there are any commits since this run was last triggered and either push or set the output
         if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
         run: |
+          echo "Running linter and tests"
+          npm run lint && npm run test
+          git commit -am "Apply linter fixes" --no-verify || true
+
           CHANGES_COUNT=$(git diff --shortstat origin/nightly | wc -l)
           MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"
           echo "Number of changes: $CHANGES_COUNT"


### PR DESCRIPTION
### Description
Split the process of dependency updates and linter fixes from the `nightly` branch and into the `develop` branch.

### Motivation and Context
As contributors, I realized that if these submodule, dependencies and linter changes go only in the `nightly` branch, then we are always running locally without these module-updates (ie while developing) on the `develop` branch. The same goes for the submodules (mainly `recipes`).

Also, with the old style prior to this PR, the number of responsibilities that were being done as part of the nightly build process seemed to keep growing. Since we have the ability to define different build workflows in GH Actions, splitting into a new simplified workflow seems best at this point in time.

As a consequence of the 2nd commit, we should now also see a reduction in the time taken to determine whether a new nightly build should proceed or not.

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint`)
- [x] I tested/previewed my changes locally