### PR TITLE
Use utility methods from 'electron-util'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15866,6 +15866,11 @@
       "resolved": "https://registry.npmjs.org/electron-find/-/electron-find-1.0.6.tgz",
       "integrity": "sha512-RenjzlCCzX7edLywLy+qRYvzds11sBv8+SrJu/3l3eVLt9d9uNqCPk+uFZ525uAhSUaUalgZWDlhQdxIgT1khg=="
     },
+    "electron-is-dev": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
+      "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
+    },
     "electron-notarize": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.0.0.tgz",
@@ -16613,19 +16618,12 @@
       }
     },
     "electron-util": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/electron-util/-/electron-util-0.16.0.tgz",
-      "integrity": "sha512-r13cauuQ8p8d++ZVdeMDtQ2VlpblJBcpKnK7sf2tGnN8CCWyRGYerS2K5f3FiblFIQkyS0rE4tFVG0IOEc2F3A==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/electron-util/-/electron-util-0.17.0.tgz",
+      "integrity": "sha512-61+NEPdIN68EBC9XDPNAKs14HlPdc7HsL6lfQ+QTiya+3BMzayBqUsvN1LrT7IoGpPuuZns+iaCKf1N78dEF+w==",
       "requires": {
         "electron-is-dev": "^1.1.0",
         "new-github-issue-url": "^0.2.1"
-      },
-      "dependencies": {
-        "electron-is-dev": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
-          "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
-        }
       }
     },
     "electron-window-state": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "electron-find": "1.0.6",
     "electron-react-titlebar": "0.8.2",
     "electron-updater": "4.3.9",
-    "electron-util": "0.16.0",
+    "electron-util": "0.17.0",
     "electron-window-state": "5.0.3",
     "fs-extra": "10.0.0",
     "gulp-csso": "4.0.1",

--- a/src/helpers/userAgent-helpers.js
+++ b/src/helpers/userAgent-helpers.js
@@ -1,8 +1,8 @@
 import os from 'os';
 import macosVersion from 'macos-version';
-import { app, isMac, isWindows } from '../environment';
-
-export const ferdiVersion = app.getVersion();
+import {
+  ferdiVersion, electronVersion, chromeVersion, isMac, isWindows,
+} from '../environment';
 
 function macOS() {
   const version = macosVersion();
@@ -34,17 +34,17 @@ export default function userAgent(removeChromeVersion = false, addFerdiVersion =
     platformString = linux();
   }
 
-  let chromeVersion = 'Chrome';
+  let chromeVersionString = 'Chrome';
   if (!removeChromeVersion) {
-    chromeVersion = `Chrome/${process.versions.chrome}`;
+    chromeVersionString = `Chrome/${chromeVersion}`;
   }
 
   let applicationString = '';
   if (addFerdiVersion) {
-    applicationString = ` Ferdi/${ferdiVersion} Electron/${process.versions.electron}`;
+    applicationString = ` Ferdi/${ferdiVersion} Electron/${electronVersion}`;
   }
 
   // Chrome is pinned to WebKit 537.36, the latest version before hard forking to Blink.
-  return `Mozilla/5.0 (${platformString}) AppleWebKit/537.36 (KHTML, like Gecko) ${chromeVersion} Safari/537.36${applicationString}`;
+  return `Mozilla/5.0 (${platformString}) AppleWebKit/537.36 (KHTML, like Gecko) ${chromeVersionString} Safari/537.36${applicationString}`;
   // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36 Ferdi/5.5.1-nightly.13 Electron/8.2.3
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ import {
   isMac,
   isWindows,
   isLinux,
+  aboutAppDetails,
 } from './environment';
 
 import { mainIpcHandler as basicAuthHandler } from './features/basicAuth';
@@ -34,14 +35,12 @@ import Settings from './electron/Settings';
 import handleDeepLink from './electron/deepLinking';
 import { isPositionValid } from './electron/windowUtils';
 import { appId } from './package.json'; // eslint-disable-line import/no-unresolved
-import * as buildInfo from './buildInfo.json'; // eslint-disable-line import/no-unresolved
 import './electron/exception';
 
 import { asarPath } from './helpers/asar-helpers';
 import { isValidExternalURL } from './helpers/url-helpers';
-import userAgent, { ferdiVersion } from './helpers/userAgent-helpers';
+import userAgent from './helpers/userAgent-helpers';
 
-const osName = require('os-name');
 const debug = require('debug')('Ferdi:App');
 
 // From Electron 9 onwards, app.allowRendererProcessReuse = true by default. This causes the app to crash on Windows due to the
@@ -147,7 +146,7 @@ if (!settings.get('enableGPUAcceleration')) {
 }
 
 app.setAboutPanelOptions({
-  applicationVersion: `Version: ${ferdiVersion}\nElectron: ${process.versions.electron}\nChrome: ${process.versions.chrome}\nNode.js: ${process.versions.node}\nPlatform: ${osName()}\nArch: ${process.arch}\nBuild date: ${new Date(Number(buildInfo.timestamp))}\nGit SHA: ${buildInfo.gitHashShort}\nGit branch: ${buildInfo.gitBranch}`,
+  applicationVersion: aboutAppDetails(),
   version: '',
 });
 
@@ -156,7 +155,7 @@ const createWindow = () => {
   const mainWindowState = windowStateKeeper({
     defaultWidth: DEFAULT_WINDOW_OPTIONS.width,
     defaultHeight: DEFAULT_WINDOW_OPTIONS.height,
-    maximize: true, // Automatically maximizes the window, if it was last clsoed maximized
+    maximize: true, // Automatically maximizes the window, if it was last closed maximized
     fullScreen: true, // Automatically restores the window to full screen, if it was last closed full screen
   });
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -6,7 +6,7 @@ import { autorun, observable } from 'mobx';
 import { defineMessages } from 'react-intl';
 import { CUSTOM_WEBSITE_RECIPE_ID, GITHUB_FERDI_URL, LIVE_API_FERDI_WEBSITE } from '../config';
 import {
-  cmdKey, ctrlKey, isLinux, isMac, termsBase,
+  cmdKey, ctrlKey, isLinux, isMac, aboutAppDetails, termsBase,
 } from '../environment';
 import { announcementsStore } from '../features/announcements';
 import { announcementActions } from '../features/announcements/actions';
@@ -14,10 +14,6 @@ import { todosStore } from '../features/todos';
 import { todoActions } from '../features/todos/actions';
 import { workspaceActions } from '../features/workspaces/actions';
 import { workspaceStore } from '../features/workspaces/index';
-import * as buildInfo from '../buildInfo.json'; // eslint-disable-line import/no-unresolved
-import { ferdiVersion } from '../helpers/userAgent-helpers';
-
-const osName = require('os-name');
 
 const menuItems = defineMessages({
   edit: {
@@ -1025,7 +1021,7 @@ export default class FranzMenu {
           type: 'info',
           title: 'Franz Ferdinand',
           message: 'Ferdi',
-          detail: `Version: ${ferdiVersion}\nElectron: ${process.versions.electron}\nChrome: ${process.versions.chrome}\nNode.js: ${process.versions.node}\nPlatform: ${osName()}\nArch: ${process.arch}\nBuild date: ${new Date(Number(buildInfo.timestamp))}\nGit SHA: ${buildInfo.gitHashShort}\nGit branch: ${buildInfo.gitBranch}`,
+          detail: aboutAppDetails(),
         });
       },
     };

--- a/src/stores/AppStore.js
+++ b/src/stores/AppStore.js
@@ -14,7 +14,9 @@ import { readJsonSync } from 'fs-extra';
 import Store from './lib/Store';
 import Request from './lib/Request';
 import { CHECK_INTERVAL } from '../config';
-import { DEFAULT_APP_SETTINGS, isMac } from '../environment';
+import {
+  DEFAULT_APP_SETTINGS, isMac, ferdiVersion, electronVersion,
+} from '../environment';
 import locales from '../i18n/translations';
 import { onVisibilityChange } from '../helpers/visibility-helper';
 import { getLocale } from '../helpers/i18n-helpers';
@@ -263,8 +265,8 @@ export default class AppStore extends Store {
         screens: screen.getAllDisplays(),
       },
       ferdi: {
-        version: app.getVersion(),
-        electron: process.versions.electron,
+        version: ferdiVersion,
+        electron: electronVersion,
         installedRecipes: this.stores.recipes.all.map(recipe => ({
           id: recipe.id,
           version: recipe.version,


### PR DESCRIPTION
### Description
`electron-util` is already a dependency. Rather than re-implementing by ourselves, I am reusing methods that this library exposes.

### Motivation and Context
Code cleanup

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding`)
- [x] I tested/previewed my changes locally
