### PR TITLE
Use useragent generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36049,9 +36049,8 @@
       }
     },
     "useragent-generator": {
-      "version": "1.1.1-amkt-22079-finish.0",
-      "resolved": "https://registry.npmjs.org/useragent-generator/-/useragent-generator-1.1.1-amkt-22079-finish.0.tgz",
-      "integrity": "sha512-jUVHvx1t3bVjx2dI9fG4iKzjO5WA6qtjWaR/PitNvd6zQMJNlFYehNwRUaAAKkhBCkw1T0U9e2oG9Sg3wSmc6Q==",
+      "version": "github:vraravam/useragent-generator#61926ecf3d4b61b021d71953a6dbed3500f7c40a",
+      "from": "github:vraravam/useragent-generator#upgrade-constants",
       "requires": {
         "normalize-version": "^1.0.5",
         "semver": "^5.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28853,6 +28853,11 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A=="
     },
+    "normalize-version": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/normalize-version/-/normalize-version-1.0.5.tgz",
+      "integrity": "sha1-pqK5AC3G+i5fFewvCywChPtJlxI="
+    },
     "now-and-later": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
@@ -33022,6 +33027,21 @@
         }
       }
     },
+    "semver-closest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/semver-closest/-/semver-closest-0.1.2.tgz",
+      "integrity": "sha512-Q6qk0bPNlK5zG62mWFC8L0Qc6OJX76XRWxiPgZyrh98IZTL3HPErgUlPfCyrAPsHVpU+YP4lf5Mz+LzpId91Og==",
+      "requires": {
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
@@ -36026,6 +36046,23 @@
       "requires": {
         "lru-cache": "4.1.x",
         "tmp": "0.0.x"
+      }
+    },
+    "useragent-generator": {
+      "version": "1.1.1-amkt-22079-finish.0",
+      "resolved": "https://registry.npmjs.org/useragent-generator/-/useragent-generator-1.1.1-amkt-22079-finish.0.tgz",
+      "integrity": "sha512-jUVHvx1t3bVjx2dI9fG4iKzjO5WA6qtjWaR/PitNvd6zQMJNlFYehNwRUaAAKkhBCkw1T0U9e2oG9Sg3wSmc6Q==",
+      "requires": {
+        "normalize-version": "^1.0.5",
+        "semver": "^5.4.1",
+        "semver-closest": "^0.1.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "utf8-byte-length": {

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "tar": "4.4.13",
     "targz": "1.0.1",
     "terser": "4.4.0",
-    "useragent-generator": "1.1.1-amkt-22079-finish.0",
+    "useragent-generator": "vraravam/useragent-generator#upgrade-constants",
     "uuid": "3.3.3",
     "validator": "11.0.0",
     "ws": "7.4.6"

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "tar": "4.4.13",
     "targz": "1.0.1",
     "terser": "4.4.0",
+    "useragent-generator": "1.1.1-amkt-22079-finish.0",
     "uuid": "3.3.3",
     "validator": "11.0.0",
     "ws": "7.4.6"

--- a/src/helpers/userAgent-helpers.js
+++ b/src/helpers/userAgent-helpers.js
@@ -1,50 +1,7 @@
-import os from 'os';
-import macosVersion from 'macos-version';
-import {
-  ferdiVersion, electronVersion, chromeVersion, isMac, isWindows,
-} from '../environment';
+import { chromeVersion } from '../environment';
 
-function macOS() {
-  const version = macosVersion();
-  return `Macintosh; Intel Mac OS X ${version.replace(/\./g, '_')}`;
-}
+const uaGenerator = require('useragent-generator');
 
-function windows() {
-  const version = os.release();
-  const [majorVersion, minorVersion] = version.split('.');
-  return `Windows NT ${majorVersion}.${minorVersion}; Win64; x64`;
-}
-
-function linux() {
-  return 'X11; Ubuntu; Linux x86_64';
-}
-
-export function isChromeless(url) {
-  return url.startsWith('https://accounts.google.com');
-}
-
-export default function userAgent(removeChromeVersion = false, addFerdiVersion = false) {
-  let platformString = '';
-
-  if (isMac) {
-    platformString = macOS();
-  } else if (isWindows) {
-    platformString = windows();
-  } else {
-    platformString = linux();
-  }
-
-  let chromeVersionString = 'Chrome';
-  if (!removeChromeVersion) {
-    chromeVersionString = `Chrome/${chromeVersion}`;
-  }
-
-  let applicationString = '';
-  if (addFerdiVersion) {
-    applicationString = ` Ferdi/${ferdiVersion} Electron/${electronVersion}`;
-  }
-
-  // Chrome is pinned to WebKit 537.36, the latest version before hard forking to Blink.
-  return `Mozilla/5.0 (${platformString}) AppleWebKit/537.36 (KHTML, like Gecko) ${chromeVersionString} Safari/537.36${applicationString}`;
-  // Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.163 Safari/537.36 Ferdi/5.5.1-nightly.13 Electron/8.2.3
+export default function userAgent() {
+  return uaGenerator.chrome(chromeVersion);
 }

--- a/src/helpers/userAgent-helpers.js
+++ b/src/helpers/userAgent-helpers.js
@@ -1,7 +1,44 @@
-import { chromeVersion } from '../environment';
+import os from 'os';
+import macosVersion from 'macos-version';
+import { chromeVersion, isMac, isWindows } from '../environment';
 
 const uaGenerator = require('useragent-generator');
 
+function is64Bit() {
+  return os.arch().match(/64/);
+}
+
+function macOS() {
+  const version = macosVersion();
+  let cpuName = os.cpus()[0].model.split(' ')[0];
+  if (cpuName && cpuName.match(/\(/)) {
+    cpuName = cpuName.split('(')[0];
+  }
+  return `Macintosh; ${cpuName} Mac OS X ${version.replace(/\./g, '_')}`;
+}
+
+function windows() {
+  const version = os.release();
+  const [majorVersion, minorVersion] = version.split('.');
+  const archString = is64Bit() ? 'Win64' : 'Win32';
+  return `Windows NT ${majorVersion}.${minorVersion}; ${archString}; ${os.arch()}`;
+}
+
+function linux() {
+  const archString = is64Bit() ? 'x86_64' : os.arch();
+  return `X11; Ubuntu; Linux ${archString}`;
+}
+
 export default function userAgent() {
-  return uaGenerator.chrome(chromeVersion);
+  let platformString = '';
+
+  if (isMac) {
+    platformString = macOS();
+  } else if (isWindows) {
+    platformString = windows();
+  } else {
+    platformString = linux();
+  }
+
+  return uaGenerator.chrome({ os: platformString, version: chromeVersion });
 }

--- a/src/models/UserAgent.js
+++ b/src/models/UserAgent.js
@@ -5,7 +5,7 @@ import {
   observable,
 } from 'mobx';
 
-import defaultUserAgent, { isChromeless } from '../helpers/userAgent-helpers';
+import defaultUserAgent from '../helpers/userAgent-helpers';
 
 const debug = require('debug')('Ferdi:UserAgent');
 
@@ -76,7 +76,7 @@ export default class UserAgent {
   }
 
   @action _handleNavigate(url, forwardingHack = false) {
-    if (isChromeless(url)) {
+    if (url.startsWith('https://accounts.google.com')) {
       if (!this.chromelessUserAgent) {
         debug('Setting user agent to chromeless for url', url);
         this.chromelessUserAgent = true;


### PR DESCRIPTION
### Description
Use `useragent-generator` to generate the user-agent string rather than building it by hand.

Marking as "draft" till [this other PR](https://github.com/getferdi/ferdi/pull/1591) gets approved and merged

### Motivation and Context
This is from the [following conversation](https://github.com/getferdi/ferdi/pull/1380#issuecomment-860531708). Intention/motivation is to avoid hardcoding - so that, as we upgrade electron (and thus chromium) versions, we can rest-assured that functionalities will continue to work.

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding`)
- [x] I tested/previewed my changes locally
