### PR TITLE
Removed references to png images

### DIFF
--- a/src/api/server/ServerApi.js
+++ b/src/api/server/ServerApi.js
@@ -624,7 +624,6 @@ export default class ServerApi {
 
         recipe.icons = {
           svg: `${recipe.path}/icon.svg`,
-          png: `${recipe.path}/icon.png`,
         };
         recipe.local = true;
 

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -7451,962 +7451,962 @@
         "defaultMessage": "!!!Edit",
         "end": {
           "column": 3,
-          "line": 26
+          "line": 22
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit",
         "start": {
           "column": 8,
-          "line": 23
+          "line": 19
         }
       },
       {
         "defaultMessage": "!!!Undo",
         "end": {
           "column": 3,
-          "line": 30
+          "line": 26
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.undo",
         "start": {
           "column": 8,
-          "line": 27
+          "line": 23
         }
       },
       {
         "defaultMessage": "!!!Redo",
         "end": {
           "column": 3,
-          "line": 34
+          "line": 30
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.redo",
         "start": {
           "column": 8,
-          "line": 31
+          "line": 27
         }
       },
       {
         "defaultMessage": "!!!Cut",
         "end": {
           "column": 3,
-          "line": 38
+          "line": 34
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.cut",
         "start": {
           "column": 7,
-          "line": 35
+          "line": 31
         }
       },
       {
         "defaultMessage": "!!!Copy",
         "end": {
           "column": 3,
-          "line": 42
+          "line": 38
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.copy",
         "start": {
           "column": 8,
-          "line": 39
+          "line": 35
         }
       },
       {
         "defaultMessage": "!!!Paste",
         "end": {
           "column": 3,
-          "line": 46
+          "line": 42
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.paste",
         "start": {
           "column": 9,
-          "line": 43
+          "line": 39
         }
       },
       {
         "defaultMessage": "!!!Paste And Match Style",
         "end": {
           "column": 3,
-          "line": 50
+          "line": 46
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.pasteAndMatchStyle",
         "start": {
           "column": 22,
-          "line": 47
+          "line": 43
         }
       },
       {
         "defaultMessage": "!!!Delete",
         "end": {
           "column": 3,
-          "line": 54
+          "line": 50
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.delete",
         "start": {
           "column": 10,
-          "line": 51
+          "line": 47
         }
       },
       {
         "defaultMessage": "!!!Select All",
         "end": {
           "column": 3,
-          "line": 58
+          "line": 54
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.selectAll",
         "start": {
           "column": 13,
-          "line": 55
+          "line": 51
         }
       },
       {
         "defaultMessage": "!!!Find in Page",
         "end": {
           "column": 3,
-          "line": 62
+          "line": 58
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.findInPage",
         "start": {
           "column": 14,
-          "line": 59
+          "line": 55
         }
       },
       {
         "defaultMessage": "!!!Speech",
         "end": {
           "column": 3,
-          "line": 66
+          "line": 62
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.speech",
         "start": {
           "column": 10,
-          "line": 63
+          "line": 59
         }
       },
       {
         "defaultMessage": "!!!Start Speaking",
         "end": {
           "column": 3,
-          "line": 70
+          "line": 66
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.startSpeaking",
         "start": {
           "column": 17,
-          "line": 67
+          "line": 63
         }
       },
       {
         "defaultMessage": "!!!Stop Speaking",
         "end": {
           "column": 3,
-          "line": 74
+          "line": 70
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.stopSpeaking",
         "start": {
           "column": 16,
-          "line": 71
+          "line": 67
         }
       },
       {
         "defaultMessage": "!!!Start Dictation",
         "end": {
           "column": 3,
-          "line": 78
+          "line": 74
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.startDictation",
         "start": {
           "column": 18,
-          "line": 75
+          "line": 71
         }
       },
       {
         "defaultMessage": "!!!Emoji & Symbols",
         "end": {
           "column": 3,
-          "line": 82
+          "line": 78
         },
         "file": "src/lib/Menu.js",
         "id": "menu.edit.emojiSymbols",
         "start": {
           "column": 16,
-          "line": 79
+          "line": 75
         }
       },
       {
         "defaultMessage": "!!!Open Quick Switch",
         "end": {
           "column": 3,
-          "line": 86
+          "line": 82
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.openQuickSwitch",
         "start": {
           "column": 19,
-          "line": 83
+          "line": 79
         }
       },
       {
         "defaultMessage": "!!!Back",
         "end": {
           "column": 3,
-          "line": 90
+          "line": 86
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.back",
         "start": {
           "column": 8,
-          "line": 87
+          "line": 83
         }
       },
       {
         "defaultMessage": "!!!Forward",
         "end": {
           "column": 3,
-          "line": 94
+          "line": 90
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.forward",
         "start": {
           "column": 11,
-          "line": 91
+          "line": 87
         }
       },
       {
         "defaultMessage": "!!!Actual Size",
         "end": {
           "column": 3,
-          "line": 98
+          "line": 94
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.resetZoom",
         "start": {
           "column": 13,
-          "line": 95
+          "line": 91
         }
       },
       {
         "defaultMessage": "!!!Zoom In",
         "end": {
           "column": 3,
-          "line": 102
+          "line": 98
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.zoomIn",
         "start": {
           "column": 10,
-          "line": 99
+          "line": 95
         }
       },
       {
         "defaultMessage": "!!!Zoom Out",
         "end": {
           "column": 3,
-          "line": 106
+          "line": 102
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.zoomOut",
         "start": {
           "column": 11,
-          "line": 103
+          "line": 99
         }
       },
       {
         "defaultMessage": "!!!Enter Full Screen",
         "end": {
           "column": 3,
-          "line": 110
+          "line": 106
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.enterFullScreen",
         "start": {
           "column": 19,
-          "line": 107
+          "line": 103
         }
       },
       {
         "defaultMessage": "!!!Exit Full Screen",
         "end": {
           "column": 3,
-          "line": 114
+          "line": 110
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.exitFullScreen",
         "start": {
           "column": 18,
-          "line": 111
+          "line": 107
         }
       },
       {
         "defaultMessage": "!!!Toggle Full Screen",
         "end": {
           "column": 3,
-          "line": 118
+          "line": 114
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleFullScreen",
         "start": {
           "column": 20,
-          "line": 115
+          "line": 111
         }
       },
       {
         "defaultMessage": "!!!Toggle Dark Mode",
         "end": {
           "column": 3,
-          "line": 122
+          "line": 118
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleDarkMode",
         "start": {
           "column": 18,
-          "line": 119
+          "line": 115
         }
       },
       {
         "defaultMessage": "!!!Toggle Developer Tools",
         "end": {
           "column": 3,
-          "line": 126
+          "line": 122
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleDevTools",
         "start": {
           "column": 18,
-          "line": 123
+          "line": 119
         }
       },
       {
         "defaultMessage": "!!!Toggle Todos Developer Tools",
         "end": {
           "column": 3,
-          "line": 130
+          "line": 126
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleTodosDevTools",
         "start": {
           "column": 23,
-          "line": 127
+          "line": 123
         }
       },
       {
         "defaultMessage": "!!!Toggle Service Developer Tools",
         "end": {
           "column": 3,
-          "line": 134
+          "line": 130
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.toggleServiceDevTools",
         "start": {
           "column": 25,
-          "line": 131
+          "line": 127
         }
       },
       {
         "defaultMessage": "!!!Reload Service",
         "end": {
           "column": 3,
-          "line": 138
+          "line": 134
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.reloadService",
         "start": {
           "column": 17,
-          "line": 135
+          "line": 131
         }
       },
       {
         "defaultMessage": "!!!Reload Ferdi",
         "end": {
           "column": 3,
-          "line": 142
+          "line": 138
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.reloadFranz",
         "start": {
           "column": 15,
-          "line": 139
+          "line": 135
         }
       },
       {
         "defaultMessage": "!!!Lock Ferdi",
         "end": {
           "column": 3,
-          "line": 146
+          "line": 142
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.lockFerdi",
         "start": {
           "column": 13,
-          "line": 143
+          "line": 139
         }
       },
       {
         "defaultMessage": "!!!Reload ToDos",
         "end": {
           "column": 3,
-          "line": 150
+          "line": 146
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view.reloadTodos",
         "start": {
           "column": 15,
-          "line": 147
+          "line": 143
         }
       },
       {
         "defaultMessage": "!!!Minimize",
         "end": {
           "column": 3,
-          "line": 154
+          "line": 150
         },
         "file": "src/lib/Menu.js",
         "id": "menu.window.minimize",
         "start": {
           "column": 12,
-          "line": 151
+          "line": 147
         }
       },
       {
         "defaultMessage": "!!!Close",
         "end": {
           "column": 3,
-          "line": 158
+          "line": 154
         },
         "file": "src/lib/Menu.js",
         "id": "menu.window.close",
         "start": {
           "column": 9,
-          "line": 155
+          "line": 151
         }
       },
       {
         "defaultMessage": "!!!Learn More",
         "end": {
           "column": 3,
-          "line": 162
+          "line": 158
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.learnMore",
         "start": {
           "column": 13,
-          "line": 159
+          "line": 155
         }
       },
       {
         "defaultMessage": "!!!Changelog",
         "end": {
           "column": 3,
-          "line": 166
+          "line": 162
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.changelog",
         "start": {
           "column": 13,
-          "line": 163
+          "line": 159
         }
       },
       {
         "defaultMessage": "!!!Support",
         "end": {
           "column": 3,
-          "line": 170
+          "line": 166
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.support",
         "start": {
           "column": 11,
-          "line": 167
+          "line": 163
         }
       },
       {
         "defaultMessage": "!!!Copy Debug Information",
         "end": {
           "column": 3,
-          "line": 174
+          "line": 170
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.debugInfo",
         "start": {
           "column": 13,
-          "line": 171
+          "line": 167
         }
       },
       {
         "defaultMessage": "!!!Publish Debug Information",
         "end": {
           "column": 3,
-          "line": 178
+          "line": 174
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.publishDebugInfo",
         "start": {
           "column": 20,
-          "line": 175
+          "line": 171
         }
       },
       {
         "defaultMessage": "!!!Ferdi Debug Information",
         "end": {
           "column": 3,
-          "line": 182
+          "line": 178
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.debugInfoCopiedHeadline",
         "start": {
           "column": 27,
-          "line": 179
+          "line": 175
         }
       },
       {
         "defaultMessage": "!!!Your Debug Information has been copied to your clipboard.",
         "end": {
           "column": 3,
-          "line": 186
+          "line": 182
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.debugInfoCopiedBody",
         "start": {
           "column": 23,
-          "line": 183
+          "line": 179
         }
       },
       {
         "defaultMessage": "!!!Unlock with Touch ID",
         "end": {
           "column": 3,
-          "line": 190
+          "line": 186
         },
         "file": "src/lib/Menu.js",
         "id": "locked.touchId",
         "start": {
           "column": 11,
-          "line": 187
+          "line": 183
         }
       },
       {
         "defaultMessage": "!!!unlock via Touch ID",
         "end": {
           "column": 3,
-          "line": 194
+          "line": 190
         },
         "file": "src/lib/Menu.js",
         "id": "locked.touchIdPrompt",
         "start": {
           "column": 17,
-          "line": 191
+          "line": 187
         }
       },
       {
         "defaultMessage": "!!!Terms of Service",
         "end": {
           "column": 3,
-          "line": 198
+          "line": 194
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.tos",
         "start": {
           "column": 7,
-          "line": 195
+          "line": 191
         }
       },
       {
         "defaultMessage": "!!!Privacy Statement",
         "end": {
           "column": 3,
-          "line": 202
+          "line": 198
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help.privacy",
         "start": {
           "column": 11,
-          "line": 199
+          "line": 195
         }
       },
       {
         "defaultMessage": "!!!File",
         "end": {
           "column": 3,
-          "line": 206
+          "line": 202
         },
         "file": "src/lib/Menu.js",
         "id": "menu.file",
         "start": {
           "column": 8,
-          "line": 203
+          "line": 199
         }
       },
       {
         "defaultMessage": "!!!View",
         "end": {
           "column": 3,
-          "line": 210
+          "line": 206
         },
         "file": "src/lib/Menu.js",
         "id": "menu.view",
         "start": {
           "column": 8,
-          "line": 207
+          "line": 203
         }
       },
       {
         "defaultMessage": "!!!Services",
         "end": {
           "column": 3,
-          "line": 214
+          "line": 210
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services",
         "start": {
           "column": 12,
-          "line": 211
+          "line": 207
         }
       },
       {
         "defaultMessage": "!!!Window",
         "end": {
           "column": 3,
-          "line": 218
+          "line": 214
         },
         "file": "src/lib/Menu.js",
         "id": "menu.window",
         "start": {
           "column": 10,
-          "line": 215
+          "line": 211
         }
       },
       {
         "defaultMessage": "!!!Help",
         "end": {
           "column": 3,
-          "line": 222
+          "line": 218
         },
         "file": "src/lib/Menu.js",
         "id": "menu.help",
         "start": {
           "column": 8,
-          "line": 219
+          "line": 215
         }
       },
       {
         "defaultMessage": "!!!About Ferdi",
         "end": {
           "column": 3,
-          "line": 226
+          "line": 222
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.about",
         "start": {
           "column": 9,
-          "line": 223
+          "line": 219
         }
       },
       {
         "defaultMessage": "!!!What's new?",
         "end": {
           "column": 3,
-          "line": 230
+          "line": 226
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.announcement",
         "start": {
           "column": 16,
-          "line": 227
+          "line": 223
         }
       },
       {
         "defaultMessage": "!!!Settings",
         "end": {
           "column": 3,
-          "line": 234
+          "line": 230
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.settings",
         "start": {
           "column": 12,
-          "line": 231
+          "line": 227
         }
       },
       {
         "defaultMessage": "!!!Check for updates",
         "end": {
           "column": 3,
-          "line": 238
+          "line": 234
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.checkForUpdates",
         "start": {
           "column": 19,
-          "line": 235
+          "line": 231
         }
       },
       {
         "defaultMessage": "!!!Hide",
         "end": {
           "column": 3,
-          "line": 242
+          "line": 238
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.hide",
         "start": {
           "column": 8,
-          "line": 239
+          "line": 235
         }
       },
       {
         "defaultMessage": "!!!Hide Others",
         "end": {
           "column": 3,
-          "line": 246
+          "line": 242
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.hideOthers",
         "start": {
           "column": 14,
-          "line": 243
+          "line": 239
         }
       },
       {
         "defaultMessage": "!!!Unhide",
         "end": {
           "column": 3,
-          "line": 250
+          "line": 246
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.unhide",
         "start": {
           "column": 10,
-          "line": 247
+          "line": 243
         }
       },
       {
         "defaultMessage": "!!!Auto-hide menu bar",
         "end": {
           "column": 3,
-          "line": 254
+          "line": 250
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.autohideMenuBar",
         "start": {
           "column": 19,
-          "line": 251
+          "line": 247
         }
       },
       {
         "defaultMessage": "!!!Quit",
         "end": {
           "column": 3,
-          "line": 258
+          "line": 254
         },
         "file": "src/lib/Menu.js",
         "id": "menu.app.quit",
         "start": {
           "column": 8,
-          "line": 255
+          "line": 251
         }
       },
       {
         "defaultMessage": "!!!Add New Service...",
         "end": {
           "column": 3,
-          "line": 262
+          "line": 258
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.addNewService",
         "start": {
           "column": 17,
-          "line": 259
+          "line": 255
         }
       },
       {
         "defaultMessage": "!!!Add New Workspace...",
         "end": {
           "column": 3,
-          "line": 266
+          "line": 262
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.addNewWorkspace",
         "start": {
           "column": 19,
-          "line": 263
+          "line": 259
         }
       },
       {
         "defaultMessage": "!!!Open workspace drawer",
         "end": {
           "column": 3,
-          "line": 270
+          "line": 266
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.openWorkspaceDrawer",
         "start": {
           "column": 23,
-          "line": 267
+          "line": 263
         }
       },
       {
         "defaultMessage": "!!!Close workspace drawer",
         "end": {
           "column": 3,
-          "line": 274
+          "line": 270
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.closeWorkspaceDrawer",
         "start": {
           "column": 24,
-          "line": 271
+          "line": 267
         }
       },
       {
         "defaultMessage": "!!!Activate next service...",
         "end": {
           "column": 3,
-          "line": 278
+          "line": 274
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.setNextServiceActive",
         "start": {
           "column": 23,
-          "line": 275
+          "line": 271
         }
       },
       {
         "defaultMessage": "!!!Activate previous service...",
         "end": {
           "column": 3,
-          "line": 282
+          "line": 278
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.activatePreviousService",
         "start": {
           "column": 27,
-          "line": 279
+          "line": 275
         }
       },
       {
         "defaultMessage": "!!!Disable notifications & audio",
         "end": {
           "column": 3,
-          "line": 286
+          "line": 282
         },
         "file": "src/lib/Menu.js",
         "id": "sidebar.muteApp",
         "start": {
           "column": 11,
-          "line": 283
+          "line": 279
         }
       },
       {
         "defaultMessage": "!!!Enable notifications & audio",
         "end": {
           "column": 3,
-          "line": 290
+          "line": 286
         },
         "file": "src/lib/Menu.js",
         "id": "sidebar.unmuteApp",
         "start": {
           "column": 13,
-          "line": 287
+          "line": 283
         }
       },
       {
         "defaultMessage": "!!!Workspaces",
         "end": {
           "column": 3,
-          "line": 294
+          "line": 290
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces",
         "start": {
           "column": 14,
-          "line": 291
+          "line": 287
         }
       },
       {
         "defaultMessage": "!!!Default",
         "end": {
           "column": 3,
-          "line": 298
+          "line": 294
         },
         "file": "src/lib/Menu.js",
         "id": "menu.workspaces.defaultWorkspace",
         "start": {
           "column": 20,
-          "line": 295
+          "line": 291
         }
       },
       {
         "defaultMessage": "!!!Todos",
         "end": {
           "column": 3,
-          "line": 302
+          "line": 298
         },
         "file": "src/lib/Menu.js",
         "id": "menu.todos",
         "start": {
           "column": 9,
-          "line": 299
+          "line": 295
         }
       },
       {
         "defaultMessage": "!!!Open Todos drawer",
         "end": {
           "column": 3,
-          "line": 306
+          "line": 302
         },
         "file": "src/lib/Menu.js",
         "id": "menu.Todoss.openTodosDrawer",
         "start": {
           "column": 19,
-          "line": 303
+          "line": 299
         }
       },
       {
         "defaultMessage": "!!!Close Todos drawer",
         "end": {
           "column": 3,
-          "line": 310
+          "line": 306
         },
         "file": "src/lib/Menu.js",
         "id": "menu.Todoss.closeTodosDrawer",
         "start": {
           "column": 20,
-          "line": 307
+          "line": 303
         }
       },
       {
         "defaultMessage": "!!!Enable Todos",
         "end": {
           "column": 3,
-          "line": 314
+          "line": 310
         },
         "file": "src/lib/Menu.js",
         "id": "menu.todos.enableTodos",
         "start": {
           "column": 15,
-          "line": 311
+          "line": 307
         }
       },
       {
         "defaultMessage": "!!!Home",
         "end": {
           "column": 3,
-          "line": 318
+          "line": 314
         },
         "file": "src/lib/Menu.js",
         "id": "menu.services.goHome",
         "start": {
           "column": 17,
-          "line": 315
+          "line": 311
         }
       }
     ],

--- a/src/i18n/messages/src/lib/Menu.json
+++ b/src/i18n/messages/src/lib/Menu.json
@@ -4,6 +4,19 @@
     "defaultMessage": "!!!Edit",
     "file": "src/lib/Menu.js",
     "start": {
+      "line": 19,
+      "column": 8
+    },
+    "end": {
+      "line": 22,
+      "column": 3
+    }
+  },
+  {
+    "id": "menu.edit.undo",
+    "defaultMessage": "!!!Undo",
+    "file": "src/lib/Menu.js",
+    "start": {
       "line": 23,
       "column": 8
     },
@@ -13,8 +26,8 @@
     }
   },
   {
-    "id": "menu.edit.undo",
-    "defaultMessage": "!!!Undo",
+    "id": "menu.edit.redo",
+    "defaultMessage": "!!!Redo",
     "file": "src/lib/Menu.js",
     "start": {
       "line": 27,
@@ -26,28 +39,15 @@
     }
   },
   {
-    "id": "menu.edit.redo",
-    "defaultMessage": "!!!Redo",
-    "file": "src/lib/Menu.js",
-    "start": {
-      "line": 31,
-      "column": 8
-    },
-    "end": {
-      "line": 34,
-      "column": 3
-    }
-  },
-  {
     "id": "menu.edit.cut",
     "defaultMessage": "!!!Cut",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 35,
+      "line": 31,
       "column": 7
     },
     "end": {
-      "line": 38,
+      "line": 34,
       "column": 3
     }
   },
@@ -56,11 +56,11 @@
     "defaultMessage": "!!!Copy",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 39,
+      "line": 35,
       "column": 8
     },
     "end": {
-      "line": 42,
+      "line": 38,
       "column": 3
     }
   },
@@ -69,11 +69,11 @@
     "defaultMessage": "!!!Paste",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 43,
+      "line": 39,
       "column": 9
     },
     "end": {
-      "line": 46,
+      "line": 42,
       "column": 3
     }
   },
@@ -82,11 +82,11 @@
     "defaultMessage": "!!!Paste And Match Style",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 47,
+      "line": 43,
       "column": 22
     },
     "end": {
-      "line": 50,
+      "line": 46,
       "column": 3
     }
   },
@@ -95,11 +95,11 @@
     "defaultMessage": "!!!Delete",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 51,
+      "line": 47,
       "column": 10
     },
     "end": {
-      "line": 54,
+      "line": 50,
       "column": 3
     }
   },
@@ -108,11 +108,11 @@
     "defaultMessage": "!!!Select All",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 55,
+      "line": 51,
       "column": 13
     },
     "end": {
-      "line": 58,
+      "line": 54,
       "column": 3
     }
   },
@@ -121,11 +121,11 @@
     "defaultMessage": "!!!Find in Page",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 59,
+      "line": 55,
       "column": 14
     },
     "end": {
-      "line": 62,
+      "line": 58,
       "column": 3
     }
   },
@@ -134,11 +134,11 @@
     "defaultMessage": "!!!Speech",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 63,
+      "line": 59,
       "column": 10
     },
     "end": {
-      "line": 66,
+      "line": 62,
       "column": 3
     }
   },
@@ -147,11 +147,11 @@
     "defaultMessage": "!!!Start Speaking",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 67,
+      "line": 63,
       "column": 17
     },
     "end": {
-      "line": 70,
+      "line": 66,
       "column": 3
     }
   },
@@ -160,11 +160,11 @@
     "defaultMessage": "!!!Stop Speaking",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 71,
+      "line": 67,
       "column": 16
     },
     "end": {
-      "line": 74,
+      "line": 70,
       "column": 3
     }
   },
@@ -173,11 +173,11 @@
     "defaultMessage": "!!!Start Dictation",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 75,
+      "line": 71,
       "column": 18
     },
     "end": {
-      "line": 78,
+      "line": 74,
       "column": 3
     }
   },
@@ -186,11 +186,11 @@
     "defaultMessage": "!!!Emoji & Symbols",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 79,
+      "line": 75,
       "column": 16
     },
     "end": {
-      "line": 82,
+      "line": 78,
       "column": 3
     }
   },
@@ -199,11 +199,11 @@
     "defaultMessage": "!!!Open Quick Switch",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 83,
+      "line": 79,
       "column": 19
     },
     "end": {
-      "line": 86,
+      "line": 82,
       "column": 3
     }
   },
@@ -212,11 +212,11 @@
     "defaultMessage": "!!!Back",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 87,
+      "line": 83,
       "column": 8
     },
     "end": {
-      "line": 90,
+      "line": 86,
       "column": 3
     }
   },
@@ -225,11 +225,11 @@
     "defaultMessage": "!!!Forward",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 91,
+      "line": 87,
       "column": 11
     },
     "end": {
-      "line": 94,
+      "line": 90,
       "column": 3
     }
   },
@@ -238,11 +238,11 @@
     "defaultMessage": "!!!Actual Size",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 95,
+      "line": 91,
       "column": 13
     },
     "end": {
-      "line": 98,
+      "line": 94,
       "column": 3
     }
   },
@@ -251,11 +251,11 @@
     "defaultMessage": "!!!Zoom In",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 99,
+      "line": 95,
       "column": 10
     },
     "end": {
-      "line": 102,
+      "line": 98,
       "column": 3
     }
   },
@@ -264,11 +264,11 @@
     "defaultMessage": "!!!Zoom Out",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 103,
+      "line": 99,
       "column": 11
     },
     "end": {
-      "line": 106,
+      "line": 102,
       "column": 3
     }
   },
@@ -277,11 +277,11 @@
     "defaultMessage": "!!!Enter Full Screen",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 107,
+      "line": 103,
       "column": 19
     },
     "end": {
-      "line": 110,
+      "line": 106,
       "column": 3
     }
   },
@@ -290,11 +290,11 @@
     "defaultMessage": "!!!Exit Full Screen",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 111,
+      "line": 107,
       "column": 18
     },
     "end": {
-      "line": 114,
+      "line": 110,
       "column": 3
     }
   },
@@ -303,8 +303,21 @@
     "defaultMessage": "!!!Toggle Full Screen",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 115,
+      "line": 111,
       "column": 20
+    },
+    "end": {
+      "line": 114,
+      "column": 3
+    }
+  },
+  {
+    "id": "menu.view.toggleDarkMode",
+    "defaultMessage": "!!!Toggle Dark Mode",
+    "file": "src/lib/Menu.js",
+    "start": {
+      "line": 115,
+      "column": 18
     },
     "end": {
       "line": 118,
@@ -312,8 +325,8 @@
     }
   },
   {
-    "id": "menu.view.toggleDarkMode",
-    "defaultMessage": "!!!Toggle Dark Mode",
+    "id": "menu.view.toggleDevTools",
+    "defaultMessage": "!!!Toggle Developer Tools",
     "file": "src/lib/Menu.js",
     "start": {
       "line": 119,
@@ -325,28 +338,15 @@
     }
   },
   {
-    "id": "menu.view.toggleDevTools",
-    "defaultMessage": "!!!Toggle Developer Tools",
-    "file": "src/lib/Menu.js",
-    "start": {
-      "line": 123,
-      "column": 18
-    },
-    "end": {
-      "line": 126,
-      "column": 3
-    }
-  },
-  {
     "id": "menu.view.toggleTodosDevTools",
     "defaultMessage": "!!!Toggle Todos Developer Tools",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 127,
+      "line": 123,
       "column": 23
     },
     "end": {
-      "line": 130,
+      "line": 126,
       "column": 3
     }
   },
@@ -355,11 +355,11 @@
     "defaultMessage": "!!!Toggle Service Developer Tools",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 131,
+      "line": 127,
       "column": 25
     },
     "end": {
-      "line": 134,
+      "line": 130,
       "column": 3
     }
   },
@@ -368,11 +368,11 @@
     "defaultMessage": "!!!Reload Service",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 135,
+      "line": 131,
       "column": 17
     },
     "end": {
-      "line": 138,
+      "line": 134,
       "column": 3
     }
   },
@@ -381,11 +381,11 @@
     "defaultMessage": "!!!Reload Ferdi",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 139,
+      "line": 135,
       "column": 15
     },
     "end": {
-      "line": 142,
+      "line": 138,
       "column": 3
     }
   },
@@ -394,11 +394,11 @@
     "defaultMessage": "!!!Lock Ferdi",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 143,
+      "line": 139,
       "column": 13
     },
     "end": {
-      "line": 146,
+      "line": 142,
       "column": 3
     }
   },
@@ -407,11 +407,11 @@
     "defaultMessage": "!!!Reload ToDos",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 147,
+      "line": 143,
       "column": 15
     },
     "end": {
-      "line": 150,
+      "line": 146,
       "column": 3
     }
   },
@@ -420,11 +420,11 @@
     "defaultMessage": "!!!Minimize",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 151,
+      "line": 147,
       "column": 12
     },
     "end": {
-      "line": 154,
+      "line": 150,
       "column": 3
     }
   },
@@ -433,8 +433,21 @@
     "defaultMessage": "!!!Close",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 155,
+      "line": 151,
       "column": 9
+    },
+    "end": {
+      "line": 154,
+      "column": 3
+    }
+  },
+  {
+    "id": "menu.help.learnMore",
+    "defaultMessage": "!!!Learn More",
+    "file": "src/lib/Menu.js",
+    "start": {
+      "line": 155,
+      "column": 13
     },
     "end": {
       "line": 158,
@@ -442,8 +455,8 @@
     }
   },
   {
-    "id": "menu.help.learnMore",
-    "defaultMessage": "!!!Learn More",
+    "id": "menu.help.changelog",
+    "defaultMessage": "!!!Changelog",
     "file": "src/lib/Menu.js",
     "start": {
       "line": 159,
@@ -455,28 +468,15 @@
     }
   },
   {
-    "id": "menu.help.changelog",
-    "defaultMessage": "!!!Changelog",
-    "file": "src/lib/Menu.js",
-    "start": {
-      "line": 163,
-      "column": 13
-    },
-    "end": {
-      "line": 166,
-      "column": 3
-    }
-  },
-  {
     "id": "menu.help.support",
     "defaultMessage": "!!!Support",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 167,
+      "line": 163,
       "column": 11
     },
     "end": {
-      "line": 170,
+      "line": 166,
       "column": 3
     }
   },
@@ -485,11 +485,11 @@
     "defaultMessage": "!!!Copy Debug Information",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 171,
+      "line": 167,
       "column": 13
     },
     "end": {
-      "line": 174,
+      "line": 170,
       "column": 3
     }
   },
@@ -498,11 +498,11 @@
     "defaultMessage": "!!!Publish Debug Information",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 175,
+      "line": 171,
       "column": 20
     },
     "end": {
-      "line": 178,
+      "line": 174,
       "column": 3
     }
   },
@@ -511,11 +511,11 @@
     "defaultMessage": "!!!Ferdi Debug Information",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 179,
+      "line": 175,
       "column": 27
     },
     "end": {
-      "line": 182,
+      "line": 178,
       "column": 3
     }
   },
@@ -524,11 +524,11 @@
     "defaultMessage": "!!!Your Debug Information has been copied to your clipboard.",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 183,
+      "line": 179,
       "column": 23
     },
     "end": {
-      "line": 186,
+      "line": 182,
       "column": 3
     }
   },
@@ -537,11 +537,11 @@
     "defaultMessage": "!!!Unlock with Touch ID",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 187,
+      "line": 183,
       "column": 11
     },
     "end": {
-      "line": 190,
+      "line": 186,
       "column": 3
     }
   },
@@ -550,11 +550,11 @@
     "defaultMessage": "!!!unlock via Touch ID",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 191,
+      "line": 187,
       "column": 17
     },
     "end": {
-      "line": 194,
+      "line": 190,
       "column": 3
     }
   },
@@ -563,11 +563,11 @@
     "defaultMessage": "!!!Terms of Service",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 195,
+      "line": 191,
       "column": 7
     },
     "end": {
-      "line": 198,
+      "line": 194,
       "column": 3
     }
   },
@@ -576,8 +576,21 @@
     "defaultMessage": "!!!Privacy Statement",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 199,
+      "line": 195,
       "column": 11
+    },
+    "end": {
+      "line": 198,
+      "column": 3
+    }
+  },
+  {
+    "id": "menu.file",
+    "defaultMessage": "!!!File",
+    "file": "src/lib/Menu.js",
+    "start": {
+      "line": 199,
+      "column": 8
     },
     "end": {
       "line": 202,
@@ -585,8 +598,8 @@
     }
   },
   {
-    "id": "menu.file",
-    "defaultMessage": "!!!File",
+    "id": "menu.view",
+    "defaultMessage": "!!!View",
     "file": "src/lib/Menu.js",
     "start": {
       "line": 203,
@@ -598,28 +611,15 @@
     }
   },
   {
-    "id": "menu.view",
-    "defaultMessage": "!!!View",
-    "file": "src/lib/Menu.js",
-    "start": {
-      "line": 207,
-      "column": 8
-    },
-    "end": {
-      "line": 210,
-      "column": 3
-    }
-  },
-  {
     "id": "menu.services",
     "defaultMessage": "!!!Services",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 211,
+      "line": 207,
       "column": 12
     },
     "end": {
-      "line": 214,
+      "line": 210,
       "column": 3
     }
   },
@@ -628,11 +628,11 @@
     "defaultMessage": "!!!Window",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 215,
+      "line": 211,
       "column": 10
     },
     "end": {
-      "line": 218,
+      "line": 214,
       "column": 3
     }
   },
@@ -641,11 +641,11 @@
     "defaultMessage": "!!!Help",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 219,
+      "line": 215,
       "column": 8
     },
     "end": {
-      "line": 222,
+      "line": 218,
       "column": 3
     }
   },
@@ -654,11 +654,11 @@
     "defaultMessage": "!!!About Ferdi",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 223,
+      "line": 219,
       "column": 9
     },
     "end": {
-      "line": 226,
+      "line": 222,
       "column": 3
     }
   },
@@ -667,11 +667,11 @@
     "defaultMessage": "!!!What's new?",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 227,
+      "line": 223,
       "column": 16
     },
     "end": {
-      "line": 230,
+      "line": 226,
       "column": 3
     }
   },
@@ -680,11 +680,11 @@
     "defaultMessage": "!!!Settings",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 231,
+      "line": 227,
       "column": 12
     },
     "end": {
-      "line": 234,
+      "line": 230,
       "column": 3
     }
   },
@@ -693,11 +693,11 @@
     "defaultMessage": "!!!Check for updates",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 235,
+      "line": 231,
       "column": 19
     },
     "end": {
-      "line": 238,
+      "line": 234,
       "column": 3
     }
   },
@@ -706,11 +706,11 @@
     "defaultMessage": "!!!Hide",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 239,
+      "line": 235,
       "column": 8
     },
     "end": {
-      "line": 242,
+      "line": 238,
       "column": 3
     }
   },
@@ -719,11 +719,11 @@
     "defaultMessage": "!!!Hide Others",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 243,
+      "line": 239,
       "column": 14
     },
     "end": {
-      "line": 246,
+      "line": 242,
       "column": 3
     }
   },
@@ -732,11 +732,11 @@
     "defaultMessage": "!!!Unhide",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 247,
+      "line": 243,
       "column": 10
     },
     "end": {
-      "line": 250,
+      "line": 246,
       "column": 3
     }
   },
@@ -745,11 +745,11 @@
     "defaultMessage": "!!!Auto-hide menu bar",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 251,
+      "line": 247,
       "column": 19
     },
     "end": {
-      "line": 254,
+      "line": 250,
       "column": 3
     }
   },
@@ -758,11 +758,11 @@
     "defaultMessage": "!!!Quit",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 255,
+      "line": 251,
       "column": 8
     },
     "end": {
-      "line": 258,
+      "line": 254,
       "column": 3
     }
   },
@@ -771,11 +771,11 @@
     "defaultMessage": "!!!Add New Service...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 259,
+      "line": 255,
       "column": 17
     },
     "end": {
-      "line": 262,
+      "line": 258,
       "column": 3
     }
   },
@@ -784,11 +784,11 @@
     "defaultMessage": "!!!Add New Workspace...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 263,
+      "line": 259,
       "column": 19
     },
     "end": {
-      "line": 266,
+      "line": 262,
       "column": 3
     }
   },
@@ -797,11 +797,11 @@
     "defaultMessage": "!!!Open workspace drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 267,
+      "line": 263,
       "column": 23
     },
     "end": {
-      "line": 270,
+      "line": 266,
       "column": 3
     }
   },
@@ -810,11 +810,11 @@
     "defaultMessage": "!!!Close workspace drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 271,
+      "line": 267,
       "column": 24
     },
     "end": {
-      "line": 274,
+      "line": 270,
       "column": 3
     }
   },
@@ -823,11 +823,11 @@
     "defaultMessage": "!!!Activate next service...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 275,
+      "line": 271,
       "column": 23
     },
     "end": {
-      "line": 278,
+      "line": 274,
       "column": 3
     }
   },
@@ -836,11 +836,11 @@
     "defaultMessage": "!!!Activate previous service...",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 279,
+      "line": 275,
       "column": 27
     },
     "end": {
-      "line": 282,
+      "line": 278,
       "column": 3
     }
   },
@@ -849,11 +849,11 @@
     "defaultMessage": "!!!Disable notifications & audio",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 283,
+      "line": 279,
       "column": 11
     },
     "end": {
-      "line": 286,
+      "line": 282,
       "column": 3
     }
   },
@@ -862,11 +862,11 @@
     "defaultMessage": "!!!Enable notifications & audio",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 287,
+      "line": 283,
       "column": 13
     },
     "end": {
-      "line": 290,
+      "line": 286,
       "column": 3
     }
   },
@@ -875,11 +875,11 @@
     "defaultMessage": "!!!Workspaces",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 291,
+      "line": 287,
       "column": 14
     },
     "end": {
-      "line": 294,
+      "line": 290,
       "column": 3
     }
   },
@@ -888,11 +888,11 @@
     "defaultMessage": "!!!Default",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 295,
+      "line": 291,
       "column": 20
     },
     "end": {
-      "line": 298,
+      "line": 294,
       "column": 3
     }
   },
@@ -901,11 +901,11 @@
     "defaultMessage": "!!!Todos",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 299,
+      "line": 295,
       "column": 9
     },
     "end": {
-      "line": 302,
+      "line": 298,
       "column": 3
     }
   },
@@ -914,11 +914,11 @@
     "defaultMessage": "!!!Open Todos drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 303,
+      "line": 299,
       "column": 19
     },
     "end": {
-      "line": 306,
+      "line": 302,
       "column": 3
     }
   },
@@ -927,11 +927,11 @@
     "defaultMessage": "!!!Close Todos drawer",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 307,
+      "line": 303,
       "column": 20
     },
     "end": {
-      "line": 310,
+      "line": 306,
       "column": 3
     }
   },
@@ -940,11 +940,11 @@
     "defaultMessage": "!!!Enable Todos",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 311,
+      "line": 307,
       "column": 15
     },
     "end": {
-      "line": 314,
+      "line": 310,
       "column": 3
     }
   },
@@ -953,11 +953,11 @@
     "defaultMessage": "!!!Home",
     "file": "src/lib/Menu.js",
     "start": {
-      "line": 315,
+      "line": 311,
       "column": 17
     },
     "end": {
-      "line": 318,
+      "line": 314,
       "column": 3
     }
   }

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -237,10 +237,6 @@ export default class Service {
     return Boolean(this.iconUrl);
   }
 
-  @computed get iconPNG() {
-    return path.join(this.recipe.path, 'icon.png');
-  }
-
   @computed get userAgent() {
     return this.userAgentModel.userAgent;
   }


### PR DESCRIPTION
### Description
While researching [this discussion](https://github.com/getferdi/ferdi/discussions/1601), I chanced upon the fact that Ferdi does not depend on the `*.png` images (maybe it did at an earlier date).

### Motivation and Context
By removing the remaining methods that reference the png image files, we can then safely remove the images themselves in the recipes, thus making the final installer file smaller in size while also removing dead code.

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding`)
- [x] I tested/previewed my changes locally
