### PR TITLE
Separated version number bump into the 'develop' branch from 'nightly' branch

### DIFF
--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -3,6 +3,12 @@
 name: Ferdi Dependency updates
 
 on:
+  # Manual trigger from the UI
+  workflow_dispatch:
+    inputs:
+      message:
+        description: 'Message for build'
+        required: true
   schedule:
     - cron: '0 0 * * *' # every night at 12 am
 
@@ -57,8 +63,20 @@ jobs:
           npm run apply-branding
           npm run test
 
-          echo "Committing and pushing submodules, dependency-updates and linter changes"
+          echo "Committing submodules, dependency-updates and linter changes"
           git config user.name github-actions
           git config user.email github-actions@github.com
           git commit -am "Update submodules, browserslist data updates and linter fixes [skip ci]" --no-verify || true
-          git push origin $(git rev-parse --abbrev-ref HEAD) --no-verify
+
+          echo "Bumping version number"
+          GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+          CHANGES_COUNT=$(git diff --shortstat origin/$GIT_BRANCH_NAME | wc -l)
+          MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"
+          # if this is a scheduled build or has been manually triggered with 'version bump' in the text, then bump the version number
+          if [ $MANUAL_REBUILD != "true" ] || [ "${{ contains(github.event.inputs.message, 'version bump') }}" == "true" ]; then
+            echo "Bumping version number"
+            npm version prerelease --preid=nightly
+          fi
+
+          echo "Pushing all changes"
+          git push origin $GIT_BRANCH_NAME --no-verify

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+      - name: Extract Git branch name from the currently checked out branch (not from the branch where this run was kicked off)
+        run: echo "GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+        shell: bash
       - name: Cache node modules
         uses: actions/cache@v2
         env:
@@ -48,35 +51,24 @@ jobs:
           npm i -g node-gyp@8.0.0 && npm config set node_gyp "$(which node-gyp)"
       - name: Install node dependencies recursively
         run: npx lerna bootstrap
-      - name: Update submodules, dependencies and run tests
+      - name: Update submodules
+        run: git submodule update --remote -f
+      - name: Update browserslist db
+        run: npx browserslist@latest --update-db
+      - name: Run linter, reformatter, rebrander and tests
         run: |
-          echo "Updating submodules"
-          git submodule update --remote -f
-
-          echo "Updating browserslist db"
-          npx browserslist@latest --update-db
-
-          echo "Running linter, reformatter, rebrander and tests"
           npm run lint
           npm run reformat-files
           npm run manage-translations
           npm run apply-branding
           npm run test
-
-          echo "Committing submodules, dependency-updates and linter changes"
+      - name: Commit submodules, dependency-updates and linter changes
+        run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           git commit -am "Update submodules, browserslist data updates and linter fixes [skip ci]" --no-verify || true
-
-          echo "Bumping version number"
-          GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-          CHANGES_COUNT=$(git diff --shortstat origin/$GIT_BRANCH_NAME | wc -l)
-          MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"
-          # if this is a scheduled build or has been manually triggered with 'version bump' in the text, then bump the version number
-          if [ $MANUAL_REBUILD != "true" ] || [ "${{ contains(github.event.inputs.message, 'version bump') }}" == "true" ]; then
-            echo "Bumping version number"
-            npm version prerelease --preid=nightly
-          fi
-
-          echo "Pushing all changes"
-          git push origin $GIT_BRANCH_NAME --no-verify
+      - name: Bump version number if this is a scheduled build or has been manually triggered with 'version bump' in the text, then bump the version number
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'version bump')) }}
+        run: npm version prerelease --preid=nightly
+      - name: Push all changes
+        run: git push origin ${{ env.GIT_BRANCH_NAME }} --no-verify

--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -54,7 +54,7 @@ jobs:
           git config user.email github-actions@github.com
 
           echo "Rebase from 'origin/develop'"
-          git rebase origin/develop
+          git rebase origin/develop --no-verify
 
           CHANGES_COUNT=$(git diff --shortstat origin/nightly | wc -l)
           MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"

--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -5,8 +5,10 @@
   # 'FERDI_PUBLISH_TOKEN' (A GitHub Personal Access Token with appropriate permissions - for publishing the built artifacts)
   # 'APPLEID' (The username of your Apple developer account - for notarizing the mac artifacts)
   # 'APPLEID_PASSWORD' (An app-specific password - for notarizing the mac artifacts)
-  # 'CSC_LINK' (The HTTPS link or local path to certificate - for code signing of mac and windows artifacts)
-  # 'CSC_KEY_PASSWORD' (The password to decrypt the certificate given in CSC_LINK - for code signing of mac and windows artifacts)
+  # 'CSC_LINK' (The HTTPS link or local path to certificate - for code signing of mac artifacts)
+  # 'CSC_KEY_PASSWORD' (The password to decrypt the certificate given in CSC_LINK - for code signing of mac artifacts)
+  # 'WIN_CSC_LINK' (The HTTPS link or local path to certificate - for code signing of windows artifacts)
+  # 'WIN_CSC_KEY_PASSWORD' (The password to decrypt the certificate given in CSC_LINK - for code signing of windows artifacts)
 
 name: Ferdi Builds
 
@@ -51,8 +53,8 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          echo "Merge from 'origin/develop'"
-          git merge --no-ff --no-verify --commit -m "Merge remote-tracking branch 'origin/develop' into HEAD" origin/develop
+          echo "Rebase from 'origin/develop'"
+          git rebase origin/develop
 
           CHANGES_COUNT=$(git diff --shortstat origin/nightly | wc -l)
           MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"
@@ -61,12 +63,7 @@ jobs:
             echo "No changes found - terminating the build"
             echo "::set-output name=should_run::false"
           else   # changes > 0 (or) MANUAL_REBUILD=true
-            if [ $MANUAL_REBUILD != "true" ] || [ "${{ contains(github.event.inputs.message, 'version bump') }}" == "true" ]; then
-              echo "Bumping version number"
-              npm version prerelease --preid=nightly
-            fi
-
-            echo "Pushing merge and version-bump commits"
+            echo "Pushing rebased commits"
             git push origin $(git rev-parse --abbrev-ref HEAD) --no-verify
           fi
 

--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -53,8 +53,8 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          echo "Rebase from 'origin/develop'"
-          git rebase origin/develop --no-verify
+          echo "Merge with fast-forward from 'origin/develop'"
+          git merge --ff-only origin/develop --no-verify
 
           CHANGES_COUNT=$(git diff --shortstat origin/nightly | wc -l)
           MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"


### PR DESCRIPTION
### Description
Separates the bumping up of the `version` inside `package.json` and `package-lock.json` from the nightly branch (still is triggered by the scheduled job a

### Motivation and Context
Currently, the `nightly` branch is **merged** from the `develop` branch. This SHA then appears in the `About` dialog of Ferdi - but, when a user reports this as part of a bug ticket, there is no way for the developer to correlate this back to the actual commit which was used to create that released app. Instead of this, if we were able to do the version-bump in the `develop` branch itself, and then **rebase** into the `nightly` branch - then `nightly` will always follow in the same steps of `develop` as opposed to being a **parallel branch**. This will enable us to debug much easier.

Ideally, I would like us to move away from the sequential-id-based numbering, and instead, move to the SHA being present in the version itself. (but, this is a much farther goal/idea).

### Screenshots
<!-- Remove the section if this does not apply. -->

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding`)
- [x] I tested/previewed my changes locally
