### PR TITLE
fix: fix breaking Tabs component

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  arrowParens: 'avoid'
+};

--- a/packages/forms/src/toggle/index.tsx
+++ b/packages/forms/src/toggle/index.tsx
@@ -10,7 +10,10 @@ import { Error } from '../error';
 import { Label } from '../label';
 import { Wrapper } from '../wrapper';
 
-interface IProps extends React.InputHTMLAttributes<HTMLInputElement>, IFormField, IWithStyle {
+interface IProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    IFormField,
+    IWithStyle {
   className?: string;
 }
 
@@ -35,7 +38,7 @@ const styles = (theme: Theme) => ({
   },
   buttonActive: {
     background: theme.toggleButtonActive,
-    left: (theme.toggleWidth - theme.toggleHeight) + 1,
+    left: theme.toggleWidth - theme.toggleHeight + 1,
   },
   input: {
     visibility: 'hidden' as any,
@@ -77,27 +80,28 @@ class ToggleComponent extends Component<IProps> {
     } = this.props;
 
     return (
-      <Wrapper
-        className={className}
-        identifier="franz-toggle"
-      >
+      <Wrapper className={className} identifier="franz-toggle">
         <Label
           title={label}
           showLabel={showLabel}
           htmlFor={id}
           className={classes.toggleLabel}
         >
-          <div className={classnames({
-            [`${classes.toggle}`]: true,
-            [`${classes.disabled}`]: disabled,
-          })}>
-            <div className={classnames({
-              [`${classes.button}`]: true,
-              [`${classes.buttonActive}`]: checked,
-            })} />
+          <div
+            className={classnames({
+              [`${classes.toggle}`]: true,
+              [`${classes.disabled}`]: disabled,
+            })}
+          >
+            <div
+              className={classnames({
+                [`${classes.button}`]: true,
+                [`${classes.buttonActive}`]: checked,
+              })}
+            />
             <input
               className={classes.input}
-              id={id || name}
+              id={id}
               type="checkbox"
               checked={checked}
               value={value}
@@ -106,9 +110,7 @@ class ToggleComponent extends Component<IProps> {
             />
           </div>
         </Label>
-        {error && (
-          <Error message={error} />
-        )}
+        {error && <Error message={error} />}
       </Wrapper>
     );
   }

--- a/src/components/ui/Tabs/Tabs.js
+++ b/src/components/ui/Tabs/Tabs.js
@@ -8,6 +8,11 @@ import { oneOrManyChildElements } from '../../../prop-types';
 export default
 @observer
 class Tab extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { active: this.props.active };
+  }
+
   static propTypes = {
     children: oneOrManyChildElements.isRequired,
     active: PropTypes.number,
@@ -17,17 +22,13 @@ class Tab extends Component {
     active: 0,
   };
 
-  componentDidMount() {
-    this.setState({ active: this.props.active });
-  }
-
   switchTab(index) {
     this.setState({ active: index });
   }
 
   render() {
     const { children: childElements } = this.props;
-    const children = childElements.filter((c) => !!c);
+    const children = childElements.filter(c => !!c);
 
     if (children.length === 1) {
       return <div>{children}</div>;


### PR DESCRIPTION
I realized that moving from `componentWillMount()` to `componentDidMount()` in a previous PR broke the Tabs component for certain services like Rocket.Chat, for others it worked fine which led to it being hard to detect.

I moved the logic to `constructor()` instead which fixes the issue.