### PR TITLE
Added a 'wakeUpStrategy' that the user can control to wake up a previ…

### DIFF
--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -347,6 +347,8 @@ export default @observer class EditSettingsForm extends Component {
                   </span>
                 </p>
 
+                <Select field={form.$('wakeUpStrategy')} />
+
                 <Hr />
 
                 {isWorkspaceEnabled && (

--- a/src/config.js
+++ b/src/config.js
@@ -41,6 +41,17 @@ export const HIBERNATION_STRATEGIES = {
   3600: 'Extremely Slow Hibernation (1hour)',
 };
 
+export const WAKE_UP_STRATEGIES = {
+  0: 'Never wake up',
+  10: 'Wake up after 10sec',
+  30: 'Wake up after 30sec',
+  60: 'Wake up after 1min',
+  300: 'Wake up after 5min',
+  600: 'Wake up after 10min',
+  1800: 'Wake up after 30min',
+  3600: 'Wake up after 1hour',
+};
+
 export const NAVIGATION_BAR_BEHAVIOURS = {
   custom: 'Show navigation bar on custom websites only',
   always: 'Show navigation bar on all services',

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -11,7 +11,7 @@ import Form from '../../lib/Form';
 import { APP_LOCALES, SPELLCHECKER_LOCALES } from '../../i18n/languages';
 import {
   HIBERNATION_STRATEGIES, SIDEBAR_WIDTH, ICON_SIZES, NAVIGATION_BAR_BEHAVIOURS, SEARCH_ENGINE_NAMES, TODO_APPS,
-  DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED, DEFAULT_IS_FEATURE_ENABLED_BY_USER,
+  DEFAULT_SETTING_KEEP_ALL_WORKSPACES_LOADED, DEFAULT_IS_FEATURE_ENABLED_BY_USER, WAKE_UP_STRATEGIES,
 } from '../../config';
 import { DEFAULT_APP_SETTINGS, isMac } from '../../environment';
 
@@ -94,6 +94,10 @@ const messages = defineMessages({
   hibernationStrategy: {
     id: 'settings.app.form.hibernationStrategy',
     defaultMessage: '!!!Hibernation strategy',
+  },
+  wakeUpStrategy: {
+    id: 'settings.app.form.wakeUpStrategy',
+    defaultMessage: '!!!Wake up strategy',
   },
   predefinedTodoServer: {
     id: 'settings.app.form.predefinedTodoServer',
@@ -255,6 +259,7 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
         hibernate: settingsData.hibernate,
         hibernateOnStartup: settingsData.hibernateOnStartup,
         hibernationStrategy: settingsData.hibernationStrategy,
+        wakeUpStrategy: settingsData.wakeUpStrategy,
         predefinedTodoServer: settingsData.predefinedTodoServer,
         customTodoServer: settingsData.customTodoServer,
         lockingFeatureEnabled: settingsData.lockingFeatureEnabled,
@@ -331,6 +336,11 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
 
     const hibernationStrategies = getSelectOptions({
       locales: HIBERNATION_STRATEGIES,
+      sort: false,
+    });
+
+    const wakeUpStrategies = getSelectOptions({
+      locales: WAKE_UP_STRATEGIES,
       sort: false,
     });
 
@@ -438,6 +448,12 @@ export default @inject('stores', 'actions') @observer class EditSettingsScreen e
           value: settings.all.app.hibernationStrategy,
           options: hibernationStrategies,
           default: DEFAULT_APP_SETTINGS.hibernationStrategy,
+        },
+        wakeUpStrategy: {
+          label: intl.formatMessage(messages.wakeUpStrategy),
+          value: settings.all.app.wakeUpStrategy,
+          options: wakeUpStrategies,
+          default: DEFAULT_APP_SETTINGS.wakeUpStrategy,
         },
         predefinedTodoServer: {
           label: intl.formatMessage(messages.predefinedTodoServer),

--- a/src/environment.js
+++ b/src/environment.js
@@ -133,7 +133,8 @@ export const DEFAULT_APP_SETTINGS = {
   scheduledDNDStart: '17:00',
   scheduledDNDEnd: '09:00',
   hibernateOnStartup: true,
-  hibernationStrategy: 300,
+  hibernationStrategy: '300', // seconds
+  wakeUpStrategy: '300', // seconds
   inactivityLock: 0,
   automaticUpdates: true,
   showServiceNavigationBar: false,

--- a/src/i18n/locales/defaultMessages.json
+++ b/src/i18n/locales/defaultMessages.json
@@ -4419,354 +4419,367 @@
         }
       },
       {
-        "defaultMessage": "!!!Todo Server",
+        "defaultMessage": "!!!Wake up strategy",
         "end": {
           "column": 3,
           "line": 101
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.wakeUpStrategy",
+        "start": {
+          "column": 18,
+          "line": 98
+        }
+      },
+      {
+        "defaultMessage": "!!!Todo Server",
+        "end": {
+          "column": 3,
+          "line": 105
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.predefinedTodoServer",
         "start": {
           "column": 24,
-          "line": 98
+          "line": 102
         }
       },
       {
         "defaultMessage": "!!!Custom TodoServer",
         "end": {
           "column": 3,
-          "line": 105
+          "line": 109
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.customTodoServer",
         "start": {
           "column": 20,
-          "line": 102
+          "line": 106
         }
       },
       {
         "defaultMessage": "!!!Enable Password Lock",
         "end": {
           "column": 3,
-          "line": 109
+          "line": 113
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableLock",
         "start": {
           "column": 14,
-          "line": 106
+          "line": 110
         }
       },
       {
         "defaultMessage": "!!!Password",
         "end": {
           "column": 3,
-          "line": 113
+          "line": 117
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.lockPassword",
         "start": {
           "column": 16,
-          "line": 110
+          "line": 114
         }
       },
       {
         "defaultMessage": "!!!Allow using Touch ID to unlock",
         "end": {
           "column": 3,
-          "line": 117
+          "line": 121
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.useTouchIdToUnlock",
         "start": {
           "column": 22,
-          "line": 114
+          "line": 118
         }
       },
       {
         "defaultMessage": "!!!Lock after inactivity",
         "end": {
           "column": 3,
-          "line": 121
+          "line": 125
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.inactivityLock",
         "start": {
           "column": 18,
-          "line": 118
+          "line": 122
         }
       },
       {
         "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
         "end": {
           "column": 3,
-          "line": 125
+          "line": 129
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDEnabled",
         "start": {
           "column": 23,
-          "line": 122
+          "line": 126
         }
       },
       {
         "defaultMessage": "!!!From",
         "end": {
           "column": 3,
-          "line": 129
+          "line": 133
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDStart",
         "start": {
           "column": 21,
-          "line": 126
+          "line": 130
         }
       },
       {
         "defaultMessage": "!!!To",
         "end": {
           "column": 3,
-          "line": 133
+          "line": 137
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.scheduledDNDEnd",
         "start": {
           "column": 19,
-          "line": 130
+          "line": 134
         }
       },
       {
         "defaultMessage": "!!!Language",
         "end": {
           "column": 3,
-          "line": 137
-        },
-        "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.language",
-        "start": {
-          "column": 12,
-          "line": 134
-        }
-      },
-      {
-        "defaultMessage": "!!!Dark Mode",
-        "end": {
-          "column": 3,
           "line": 141
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.darkMode",
+        "id": "settings.app.form.language",
         "start": {
           "column": 12,
           "line": 138
         }
       },
       {
-        "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
+        "defaultMessage": "!!!Dark Mode",
         "end": {
           "column": 3,
           "line": 145
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.adaptableDarkMode",
+        "id": "settings.app.form.darkMode",
         "start": {
-          "column": 21,
+          "column": 12,
           "line": 142
         }
       },
       {
-        "defaultMessage": "!!!Enable universal Dark Mode",
+        "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
         "end": {
           "column": 3,
           "line": 149
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
-        "id": "settings.app.form.universalDarkMode",
+        "id": "settings.app.form.adaptableDarkMode",
         "start": {
           "column": 21,
           "line": 146
         }
       },
       {
-        "defaultMessage": "!!!Sidebar width",
+        "defaultMessage": "!!!Enable universal Dark Mode",
         "end": {
           "column": 3,
           "line": 153
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
+        "id": "settings.app.form.universalDarkMode",
+        "start": {
+          "column": 21,
+          "line": 150
+        }
+      },
+      {
+        "defaultMessage": "!!!Sidebar width",
+        "end": {
+          "column": 3,
+          "line": 157
+        },
+        "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.serviceRibbonWidth",
         "start": {
           "column": 22,
-          "line": 150
+          "line": 154
         }
       },
       {
         "defaultMessage": "!!!Service icon size",
         "end": {
           "column": 3,
-          "line": 157
+          "line": 161
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.iconSize",
         "start": {
           "column": 12,
-          "line": 154
+          "line": 158
         }
       },
       {
         "defaultMessage": "!!!Use vertical style",
         "end": {
           "column": 3,
-          "line": 161
+          "line": 165
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.useVerticalStyle",
         "start": {
           "column": 20,
-          "line": 158
+          "line": 162
         }
       },
       {
         "defaultMessage": "!!!Always show workspace drawer",
         "end": {
           "column": 3,
-          "line": 165
+          "line": 169
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.alwaysShowWorkspaces",
         "start": {
           "column": 24,
-          "line": 162
+          "line": 166
         }
       },
       {
         "defaultMessage": "!!!Accent color",
         "end": {
           "column": 3,
-          "line": 169
+          "line": 173
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.accentColor",
         "start": {
           "column": 15,
-          "line": 166
+          "line": 170
         }
       },
       {
         "defaultMessage": "!!!Display disabled services tabs",
         "end": {
           "column": 3,
-          "line": 173
+          "line": 177
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showDisabledServices",
         "start": {
           "column": 24,
-          "line": 170
+          "line": 174
         }
       },
       {
         "defaultMessage": "!!!Show unread message badge when notifications are disabled",
         "end": {
           "column": 3,
-          "line": 177
+          "line": 181
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showMessagesBadgesWhenMuted",
         "start": {
           "column": 29,
-          "line": 174
+          "line": 178
         }
       },
       {
         "defaultMessage": "!!!Show draggable area on window",
         "end": {
           "column": 3,
-          "line": 181
+          "line": 185
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.showDragArea",
         "start": {
           "column": 16,
-          "line": 178
+          "line": 182
         }
       },
       {
         "defaultMessage": "!!!Enable spell checking",
         "end": {
           "column": 3,
-          "line": 185
+          "line": 189
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableSpellchecking",
         "start": {
           "column": 23,
-          "line": 182
+          "line": 186
         }
       },
       {
         "defaultMessage": "!!!Enable GPU Acceleration",
         "end": {
           "column": 3,
-          "line": 189
+          "line": 193
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableGPUAcceleration",
         "start": {
           "column": 25,
-          "line": 186
+          "line": 190
         }
       },
       {
         "defaultMessage": "!!!Include beta versions",
         "end": {
           "column": 3,
-          "line": 193
+          "line": 197
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.beta",
         "start": {
           "column": 8,
-          "line": 190
+          "line": 194
         }
       },
       {
         "defaultMessage": "!!!Enable updates",
         "end": {
           "column": 3,
-          "line": 197
+          "line": 201
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.automaticUpdates",
         "start": {
           "column": 20,
-          "line": 194
+          "line": 198
         }
       },
       {
         "defaultMessage": "!!!Enable Franz Todos",
         "end": {
           "column": 3,
-          "line": 201
+          "line": 205
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.enableTodos",
         "start": {
           "column": 15,
-          "line": 198
+          "line": 202
         }
       },
       {
         "defaultMessage": "!!!Keep all workspaces loaded",
         "end": {
           "column": 3,
-          "line": 205
+          "line": 209
         },
         "file": "src/containers/settings/EditSettingsScreen.js",
         "id": "settings.app.form.keepAllWorkspacesLoaded",
         "start": {
           "column": 27,
-          "line": 202
+          "line": 206
         }
       }
     ],

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -256,6 +256,7 @@
   "settings.app.form.universalDarkMode": "Enable universal Dark Mode",
   "settings.app.form.useTouchIdToUnlock": "Allow using TouchID to unlock Ferdi",
   "settings.app.form.useVerticalStyle": "Use vertical style",
+  "settings.app.form.wakeUpStrategy": "Wake up strategy",
   "settings.app.headline": "Settings",
   "settings.app.headlineAdvanced": "Advanced",
   "settings.app.headlineAppearance": "Appearance",

--- a/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
+++ b/src/i18n/messages/src/containers/settings/EditSettingsScreen.json
@@ -221,15 +221,28 @@
     }
   },
   {
+    "id": "settings.app.form.wakeUpStrategy",
+    "defaultMessage": "!!!Wake up strategy",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 98,
+      "column": 18
+    },
+    "end": {
+      "line": 101,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.predefinedTodoServer",
     "defaultMessage": "!!!Todo Server",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 98,
+      "line": 102,
       "column": 24
     },
     "end": {
-      "line": 101,
+      "line": 105,
       "column": 3
     }
   },
@@ -238,11 +251,11 @@
     "defaultMessage": "!!!Custom TodoServer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 102,
+      "line": 106,
       "column": 20
     },
     "end": {
-      "line": 105,
+      "line": 109,
       "column": 3
     }
   },
@@ -251,11 +264,11 @@
     "defaultMessage": "!!!Enable Password Lock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 106,
+      "line": 110,
       "column": 14
     },
     "end": {
-      "line": 109,
+      "line": 113,
       "column": 3
     }
   },
@@ -264,11 +277,11 @@
     "defaultMessage": "!!!Password",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 110,
+      "line": 114,
       "column": 16
     },
     "end": {
-      "line": 113,
+      "line": 117,
       "column": 3
     }
   },
@@ -277,11 +290,11 @@
     "defaultMessage": "!!!Allow using Touch ID to unlock",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 114,
+      "line": 118,
       "column": 22
     },
     "end": {
-      "line": 117,
+      "line": 121,
       "column": 3
     }
   },
@@ -290,11 +303,11 @@
     "defaultMessage": "!!!Lock after inactivity",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 118,
+      "line": 122,
       "column": 18
     },
     "end": {
-      "line": 121,
+      "line": 125,
       "column": 3
     }
   },
@@ -303,11 +316,11 @@
     "defaultMessage": "!!!Enable scheduled Do-not-Disturb",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 122,
+      "line": 126,
       "column": 23
     },
     "end": {
-      "line": 125,
+      "line": 129,
       "column": 3
     }
   },
@@ -316,11 +329,11 @@
     "defaultMessage": "!!!From",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 126,
+      "line": 130,
       "column": 21
     },
     "end": {
-      "line": 129,
+      "line": 133,
       "column": 3
     }
   },
@@ -329,21 +342,8 @@
     "defaultMessage": "!!!To",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 130,
-      "column": 19
-    },
-    "end": {
-      "line": 133,
-      "column": 3
-    }
-  },
-  {
-    "id": "settings.app.form.language",
-    "defaultMessage": "!!!Language",
-    "file": "src/containers/settings/EditSettingsScreen.js",
-    "start": {
       "line": 134,
-      "column": 12
+      "column": 19
     },
     "end": {
       "line": 137,
@@ -351,8 +351,8 @@
     }
   },
   {
-    "id": "settings.app.form.darkMode",
-    "defaultMessage": "!!!Dark Mode",
+    "id": "settings.app.form.language",
+    "defaultMessage": "!!!Language",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 138,
@@ -364,12 +364,12 @@
     }
   },
   {
-    "id": "settings.app.form.adaptableDarkMode",
-    "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
+    "id": "settings.app.form.darkMode",
+    "defaultMessage": "!!!Dark Mode",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 142,
-      "column": 21
+      "column": 12
     },
     "end": {
       "line": 145,
@@ -377,8 +377,8 @@
     }
   },
   {
-    "id": "settings.app.form.universalDarkMode",
-    "defaultMessage": "!!!Enable universal Dark Mode",
+    "id": "settings.app.form.adaptableDarkMode",
+    "defaultMessage": "!!!Synchronize dark mode with my OS's dark mode setting",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
       "line": 146,
@@ -390,15 +390,28 @@
     }
   },
   {
+    "id": "settings.app.form.universalDarkMode",
+    "defaultMessage": "!!!Enable universal Dark Mode",
+    "file": "src/containers/settings/EditSettingsScreen.js",
+    "start": {
+      "line": 150,
+      "column": 21
+    },
+    "end": {
+      "line": 153,
+      "column": 3
+    }
+  },
+  {
     "id": "settings.app.form.serviceRibbonWidth",
     "defaultMessage": "!!!Sidebar width",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 150,
+      "line": 154,
       "column": 22
     },
     "end": {
-      "line": 153,
+      "line": 157,
       "column": 3
     }
   },
@@ -407,11 +420,11 @@
     "defaultMessage": "!!!Service icon size",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 154,
+      "line": 158,
       "column": 12
     },
     "end": {
-      "line": 157,
+      "line": 161,
       "column": 3
     }
   },
@@ -420,11 +433,11 @@
     "defaultMessage": "!!!Use vertical style",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 158,
+      "line": 162,
       "column": 20
     },
     "end": {
-      "line": 161,
+      "line": 165,
       "column": 3
     }
   },
@@ -433,11 +446,11 @@
     "defaultMessage": "!!!Always show workspace drawer",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 162,
+      "line": 166,
       "column": 24
     },
     "end": {
-      "line": 165,
+      "line": 169,
       "column": 3
     }
   },
@@ -446,11 +459,11 @@
     "defaultMessage": "!!!Accent color",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 166,
+      "line": 170,
       "column": 15
     },
     "end": {
-      "line": 169,
+      "line": 173,
       "column": 3
     }
   },
@@ -459,11 +472,11 @@
     "defaultMessage": "!!!Display disabled services tabs",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 170,
+      "line": 174,
       "column": 24
     },
     "end": {
-      "line": 173,
+      "line": 177,
       "column": 3
     }
   },
@@ -472,11 +485,11 @@
     "defaultMessage": "!!!Show unread message badge when notifications are disabled",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 174,
+      "line": 178,
       "column": 29
     },
     "end": {
-      "line": 177,
+      "line": 181,
       "column": 3
     }
   },
@@ -485,11 +498,11 @@
     "defaultMessage": "!!!Show draggable area on window",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 178,
+      "line": 182,
       "column": 16
     },
     "end": {
-      "line": 181,
+      "line": 185,
       "column": 3
     }
   },
@@ -498,11 +511,11 @@
     "defaultMessage": "!!!Enable spell checking",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 182,
+      "line": 186,
       "column": 23
     },
     "end": {
-      "line": 185,
+      "line": 189,
       "column": 3
     }
   },
@@ -511,11 +524,11 @@
     "defaultMessage": "!!!Enable GPU Acceleration",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 186,
+      "line": 190,
       "column": 25
     },
     "end": {
-      "line": 189,
+      "line": 193,
       "column": 3
     }
   },
@@ -524,11 +537,11 @@
     "defaultMessage": "!!!Include beta versions",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 190,
+      "line": 194,
       "column": 8
     },
     "end": {
-      "line": 193,
+      "line": 197,
       "column": 3
     }
   },
@@ -537,11 +550,11 @@
     "defaultMessage": "!!!Enable updates",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 194,
+      "line": 198,
       "column": 20
     },
     "end": {
-      "line": 197,
+      "line": 201,
       "column": 3
     }
   },
@@ -550,11 +563,11 @@
     "defaultMessage": "!!!Enable Franz Todos",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 198,
+      "line": 202,
       "column": 15
     },
     "end": {
-      "line": 201,
+      "line": 205,
       "column": 3
     }
   },
@@ -563,11 +576,11 @@
     "defaultMessage": "!!!Keep all workspaces loaded",
     "file": "src/containers/settings/EditSettingsScreen.js",
     "start": {
-      "line": 202,
+      "line": 206,
       "column": 27
     },
     "end": {
-      "line": 205,
+      "line": 209,
       "column": 3
     }
   }

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -79,6 +79,8 @@ export default class Service {
 
   @observable lastUsed = Date.now(); // timestamp
 
+  @observable lastHibernated = null; // timestamp
+
   @observable lastPoll = Date.now();
 
   @observable lastPollAnswer = Date.now();

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -165,10 +165,19 @@ export default class ServicesStore extends Store {
    */
   _serviceMaintenance() {
     this.all.forEach((service) => {
-      // Defines which services should be hibernated.
-      if (!service.isActive && (Date.now() - service.lastUsed > ms(`${this.stores.settings.all.app.hibernationStrategy}s`))) {
-        // If service is stale, hibernate it.
-        this._hibernate({ serviceId: service.id });
+      // Defines which services should be hibernated or woken up
+      if (!service.isActive) {
+        if (!service.lastHibernated && (Date.now() - service.lastUsed > ms(`${this.stores.settings.all.app.hibernationStrategy}s`))) {
+          // If service is stale, hibernate it.
+          this._hibernate({ serviceId: service.id });
+        }
+
+        if (service.lastHibernated && Number(this.stores.settings.all.app.wakeUpStrategy) > 0) {
+          // If service is in hibernation and the wakeup time has elapsed, wake it.
+          if ((Date.now() - service.lastHibernated > ms(`${this.stores.settings.all.app.wakeUpStrategy}s`))) {
+            this._awake({ serviceId: service.id });
+          }
+        }
       }
 
       if (service.lastPoll && (service.lastPoll - service.lastPollAnswer > ms('1m'))) {
@@ -473,12 +482,11 @@ export default class ServicesStore extends Store {
     if (!keepActiveRoute) this.stores.router.push('/');
     const service = this.one(serviceId);
 
-    this.all.forEach((s, index) => {
-      this.all[index].isActive = false;
+    this.all.forEach((s) => {
+      s.isActive = false;
     });
     service.isActive = true;
     this._awake({ serviceId: service.id });
-    service.lastUsed = Date.now();
 
     if (this.isTodosServiceActive && !this.stores.todos.settings.isFeatureEnabledByUser) {
       this.actions.todos.toggleTodosFeatureVisibility();
@@ -831,19 +839,15 @@ export default class ServicesStore extends Store {
     debug(`Hibernate ${service.name}`);
 
     service.isHibernationRequested = true;
-
-    if (Number(this.stores.settings.all.app.wakeUpStrategy) > 0) {
-      setTimeout(() => {
-        this._awake({ serviceId: service.id });
-      }, ms(`${this.stores.settings.all.app.wakeUpStrategy}s`));
-    }
+    service.lastHibernated = Date.now();
   }
 
   @action _awake({ serviceId }) {
     const service = this.one(serviceId);
     debug(`Waking up from service hibernation for ${service.name}`);
     service.isHibernationRequested = false;
-    service.liveFrom = Date.now();
+    service.lastUsed = Date.now();
+    service.lastHibernated = null;
   }
 
   @action _resetLastPollTimer({ serviceId = null }) {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -824,18 +824,24 @@ export default class ServicesStore extends Store {
       return;
     }
     if (service.isActive) {
-      debug('Skipping service hibernation');
+      debug(`Skipping service hibernation for ${service.name}`);
       return;
     }
 
     debug(`Hibernate ${service.name}`);
 
     service.isHibernationRequested = true;
+
+    if (Number(this.stores.settings.all.app.wakeUpStrategy) > 0) {
+      setTimeout(() => {
+        this._awake({ serviceId: service.id });
+      }, ms(`${this.stores.settings.all.app.wakeUpStrategy}s`));
+    }
   }
 
   @action _awake({ serviceId }) {
-    debug('Waking up from service hibernation');
     const service = this.one(serviceId);
+    debug(`Waking up from service hibernation for ${service.name}`);
     service.isHibernationRequested = false;
     service.liveFrom = Date.now();
   }


### PR DESCRIPTION
…ously hibernated service.

<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
In addition to a hibernation strategy, there was an ask in #1216 to add a wake-up strategy for hibernated services

#### Motivation and Context
When a service is hibernated, there is no ability to wake up and check for notifications. If such a feature were to be present, it can be configured for optimum use of the computer's resources while still getting messages and notifications of the same.

#### Screenshots
Please see the screenshots in [this comment](https://github.com/getferdi/ferdi/issues/1216#issuecomment-885738928)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdi to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
