### PR TITLE
Moved npm version bump into the main workflow (and out of the dependency updates) so that its more 'atomic'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@
 #### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 - [ ] My pull request is properly named
-- [ ] The changes respect the code style of the project (`$ npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding`)
+- [ ] The changes respect the code style of the project (`npm run prepare-code`)
 - [ ] `npm test` passes
 - [ ] I tested/previewed my changes locally
 

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Extract Git branch name and commit from the currently checked out branch (not from the branch where this run was kicked off)
         run: |
           echo "GIT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
-          echo "GIT_COMMIT=$(git log -1 --format='%H')" >> $GITHUB_ENV
         shell: bash
       - name: Cache node modules
         uses: actions/cache@v2
@@ -64,9 +63,5 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git commit -am "Update submodules, browserslist data updates and linter fixes [skip ci]" --no-verify || true
-          echo "CHANGES_COUNT=$(git diff ${{ env.GIT_COMMIT }} | wc -l)" >> $GITHUB_ENV
-      - name: Bump version number if this is a scheduled build with changes or has been manually triggered with 'version bump' in the text, then bump the version number
-        if: ${{ (github.event_name == 'schedule' && env.CHANGES_COUNT != '0') || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'version bump')) }}
-        run: npm version prerelease --preid=nightly
       - name: Push all changes
         run: git push origin ${{ env.GIT_BRANCH_NAME }} --no-verify

--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -41,22 +41,31 @@ jobs:
     steps:
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled'
         uses: actions/checkout@v2
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]')) }}
         with:
           ref: nightly
           submodules: recursive
           fetch-depth: 0    # Note: Needed to be able to pull the 'develop' branch as well for merging
       - id: should_run
         name: Check whether there are any commits since this run was last triggered and push them and/or set the output
-        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch')) }}
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]')) }}
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
+          CHANGES_COUNT=$(git diff --shortstat origin/develop | wc -l)
+          if [ $CHANGES_COUNT -gt 0 ] || [ {{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[version bump]') }} ]; then
+            # Do the version bump in the 'develop' branch ONLY if there were other changes coming from the 'develop' branch
+            git checkout develop
+            npm version -m "%s [skip ci]" prerelease --preid=nightly
+            git push origin develop
+
+            git checkout nightly
+          fi
+
           echo "Merge with fast-forward from 'origin/develop'"
           git merge --ff-only origin/develop --no-verify
 
-          CHANGES_COUNT=$(git diff --shortstat origin/nightly | wc -l)
           MANUAL_REBUILD="${{ github.event_name == 'workflow_dispatch' }}"
           echo "Number of changes: $CHANGES_COUNT"
           if [ $CHANGES_COUNT -eq 0 ] && [ $MANUAL_REBUILD != "true" ]; then
@@ -70,7 +79,7 @@ jobs:
   build_mac:
     name: 'macos ${{ github.event.inputs.message }}'
     needs: check_updates
-    if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, 'macOS') || (!contains(github.event.inputs.message, 'macOS') && !contains(github.event.inputs.message, 'Linux') && !contains(github.event.inputs.message, 'Windows'))))) }}
+    if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[macOS]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
     runs-on: macos-10.15
     steps:
       - name: Set env vars
@@ -78,7 +87,7 @@ jobs:
           echo "NPM_CACHE=$HOME/.npm" >> $GITHUB_ENV
           echo "ELECTRON_CACHE=$HOME/.cache/electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
-          echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch') }}" >> $GITHUB_ENV
+          echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
           echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled' or this is a forced rebuild on the nightly branch
         uses: actions/checkout@v2
@@ -167,7 +176,7 @@ jobs:
   build_linux:
     name: 'ubuntu ${{ github.event.inputs.message }}'
     needs: check_updates
-    if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, 'Linux') || (!contains(github.event.inputs.message, 'macOS') && !contains(github.event.inputs.message, 'Linux') && !contains(github.event.inputs.message, 'Windows'))))) }}
+    if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[Linux]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set env vars
@@ -175,7 +184,7 @@ jobs:
           echo "NPM_CACHE=$HOME/.npm" >> $GITHUB_ENV
           echo "ELECTRON_CACHE=$HOME/.cache/electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
-          echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch') }}" >> $GITHUB_ENV
+          echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
           echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled' or this is a forced rebuild on the nightly branch
         uses: actions/checkout@v2
@@ -254,7 +263,7 @@ jobs:
   build_windows:
     name: 'windows ${{ github.event.inputs.message }}'
     needs: check_updates
-    if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, 'Windows') || (!contains(github.event.inputs.message, 'macOS') && !contains(github.event.inputs.message, 'Linux') && !contains(github.event.inputs.message, 'Windows'))))) }}
+    if: ${{ (needs.check_updates.outputs.should_run != 'false') && (github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && (contains(github.event.inputs.message, '[Windows]') || (!contains(github.event.inputs.message, '[macOS]') && !contains(github.event.inputs.message, '[Linux]') && !contains(github.event.inputs.message, '[Windows]'))))) }}
     runs-on: windows-2019
     steps:
       - name: Set env vars
@@ -263,7 +272,7 @@ jobs:
           echo "NPM_CACHE=$USERPROFILE\.npm" >> $GITHUB_ENV
           echo "ELECTRON_CACHE=$USERPROFILE\.cache\electron" >> $GITHUB_ENV
           echo "ELECTRON_BUILDER_CACHE=$USERPROFILE\.cache\electron-builder" >> $GITHUB_ENV
-          echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, 'nightly branch') }}" >> $GITHUB_ENV
+          echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
           echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
         shell: bash
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled' or this is a forced rebuild on the nightly branch

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,9 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
 
-npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding
+FILE_NAME="$(dirname "$0")/_/husky.sh"
+
+# Conditionally invoke so as to avoid running npm commands if this is a clean checkout (ie before installing npm modules)
+if [ -f $FILE_NAME ]; then
+  . $FILE_NAME
+  npm run prepare-code
+fi


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
1. Made the `npm version` run without failure even if the npm modules have not been installed. This allows the version bump to happen as close to the publishing of the artefact ie in the `ferdi-build.yml` workflow.
2. Also changed the trigger-strings to be enclosed in `[]` so that the general commit message is not mistaken by GH as being taken for turning on/off certain logic in the GH actions workflows.

#### Motivation and Context
1. To ensure that version bump is followed by the publishing in the same workflow - as opposed to currently where a contributor can effect more changes *in between* the times that both the scheduled events happen.

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`$ npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
[Internal] Fixed loophole where the version bump happens, but before the nightly is built, there can be new PRs merged.