### PR TITLE
Fix duplicate paste

### DIFF
--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -583,6 +583,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       {
         label: intl.formatMessage(menuItems.paste),
         accelerator: `${ctrlKey}+V`,
+        role: 'paste',
         click() {
           getActiveWebview().paste();
         },
@@ -590,6 +591,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       {
         label: intl.formatMessage(menuItems.pasteAndMatchStyle),
         accelerator: `${ctrlKey}+Shift+V`,
+        role: 'pasteAndMatchStyle',
         click() {
           getActiveWebview().pasteAndMatchStyle();
         },


### PR DESCRIPTION
#### Pre-flight Checklist
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Added `role`s to the paste and pasteAndMatchStyle menu items which prevents formatted text from being pasted twice. I tested this on Windows 20H2 only. 

~Also fixed an issue with wrongly displayed shortcuts in the application menu (it would show "CmdOrCtrl" instead of the platform specific "Cmd" or "Ctrl" for some menu items).~

#### Motivation and Context
This fixes #1644. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Fixed duplicate pasting of formatted text for Windows/Linux