### PR TITLE
fix: Clear cache button should not log out of services

### DIFF
--- a/src/api/server/LocalApi.js
+++ b/src/api/server/LocalApi.js
@@ -9,7 +9,7 @@ const debug = require('debug')('Ferdi:LocalApi');
 export default class LocalApi {
   // Settings
   getAppSettings(type) {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       ipcRenderer.once('appSettings', (event, resp) => {
         debug('LocalApi::getAppSettings resolves', resp.type, resp.data);
         resolve(resp);
@@ -49,10 +49,8 @@ export default class LocalApi {
     await s.clearStorageData({
       storages: [
         'appcache',
-        'cookies',
         'filesystem',
         'indexdb',
-        'localstorage',
         'shadercache',
         'websql',
         'serviceworkers',


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Description of Change
I had to remove "cookies" from `clearStorageData()` to preserve the logged in state in applications.
I had to remove "localstorage from `clearStorageData()` to preserve the custom settings and logged in state in Ferdi itself.

#### Motivation and Context
Closes https://github.com/getferdi/ferdi/issues/1734, https://github.com/getferdi/ferdi/issues/795

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally