### PR TITLE
Revert "build: add Ferdi snap package"

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -59,7 +59,6 @@ linux:
     - target: tar.gz
     - target: rpm
     - target: freebsd
-    - target: snap
 
 nsis:
   perMachine: false


### PR DESCRIPTION
Reverts getferdi/ferdi#1756 since it is blocking the release of the next nightly with new features.

The build is breaking: https://github.com/getferdi/ferdi/runs/3286451715?check_suite_focus=true#step:16:67

Also, looks like we need additional configurations in the build scripts and/or the GH actions scripts to publish: https://www.electron.build/configuration/publish