### PR TITLE
build: add Ferdi snap package

### DIFF
--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -190,7 +190,7 @@ jobs:
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
           echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
           echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
-          echo "PACKAGE_VERSION=${{ node -p "require('./package.json').version" }}" >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled' or this is a forced rebuild on the nightly branch
         uses: actions/checkout@v2
         if: ${{ github.event_name == 'schedule' || env.MANUAL_REBUILD_ON_NIGHTLY == 'true' }}

--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -190,6 +190,7 @@ jobs:
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
           echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
           echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
+          echo "PACKAGE_VERSION=${{ node -p "require('./package.json').version" }}" >> $GITHUB_ENV
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled' or this is a forced rebuild on the nightly branch
         uses: actions/checkout@v2
         if: ${{ github.event_name == 'schedule' || env.MANUAL_REBUILD_ON_NIGHTLY == 'true' }}
@@ -252,18 +253,40 @@ jobs:
         shell: bash
       - name: Build Ferdi with publish for 'nightly' branch
         if: ${{ env.GIT_BRANCH_NAME == 'nightly' }}
-        run: npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=nightlies
-        shell: bash
         env:
           GH_TOKEN: ${{ secrets.FERDI_PUBLISH_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+        run: |
+          sudo snap install snapcraft --classic
+          echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=nightlies
+          snapcraft logout
+        shell: bash
       - name: Build Ferdi with publish for 'release' branch
-        if: ${{ env.GIT_BRANCH_NAME == 'release' }}
-        run: npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi
-        shell: bash
+        if: ${{ env.GIT_BRANCH_NAME == 'release' && contains(env.PACKAGE_VERSION, 'beta') }}
         env:
           GH_TOKEN: ${{ secrets.FERDI_PUBLISH_TOKEN }}
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+        run: |
+          sudo snap install snapcraft --classic
+          echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.channels=beta
+          snapcraft logout
+        shell: bash
+      - name: Build Ferdi with publish for 'release' branch
+        if: ${{ env.GIT_BRANCH_NAME == 'release' && !contains(env.PACKAGE_VERSION, 'beta') }}
+        env:
+          GH_TOKEN: ${{ secrets.FERDI_PUBLISH_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+          SNAPCRAFT_LOGIN: ${{ secrets.SNAPCRAFT_LOGIN }}
+        run: |
+          sudo snap install snapcraft --classic
+          echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.channels=stable
+          snapcraft logout
+        shell: bash
 
   build_windows:
     name: 'windows ${{ github.event.inputs.message }}'

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -44,7 +44,7 @@ win:
       arch: [x64, ia32]
     - target: portable
       arch: [x64, ia32]
-  publisherName: 'Amine Mouafik'
+  publisherName: "Amine Mouafik"
 
 linux:
   icon: ./build-helpers/images/icons
@@ -59,6 +59,11 @@ linux:
     - target: tar.gz
     - target: rpm
     - target: freebsd
+    - target: snap
+
+snap:
+  publish:
+    provider: "snapStore"
 
 nsis:
   perMachine: false


### PR DESCRIPTION
**NOTE:** continuation of https://github.com/getferdi/ferdi/pull/1756

#### Description of Change
- add snap as build target for linux
- update GitHub actions to auto publish snap based on branch and package.json version

#### Motivation and Context
Closes #1749

So far, we have stable and edge channels deployed to Snapcraft: https://snapcraft.io/ferdi
(Might be that the stable one doesn't show up yet, because they are only refreshed periodically from Snapcraft)

Since beta is not split apart from release channels, we will have beta channel on Snapcraft once a new beta release will happen.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [X] I tested/previewed my changes locally