### PR TITLE
build: fix beta channel release for snap

### DIFF
--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -190,7 +190,6 @@ jobs:
           echo "ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder" >> $GITHUB_ENV
           echo "MANUAL_REBUILD_ON_NIGHTLY=${{ github.event_name == 'workflow_dispatch' && contains(github.event.inputs.message, '[nightly branch]') }}" >> $GITHUB_ENV
           echo "SKIP_NOTARIZATION=${{ !contains(github.repository_owner, 'getferdi') }}" >> $GITHUB_ENV
-          echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
       - name: Checkout code along with submodules for the 'nightly' branch if the trigger event is 'scheduled' or this is a forced rebuild on the nightly branch
         uses: actions/checkout@v2
         if: ${{ github.event_name == 'schedule' || env.MANUAL_REBUILD_ON_NIGHTLY == 'true' }}
@@ -242,6 +241,9 @@ jobs:
         run: npm cache clean --force
       - name: Install node dependencies recursively
         run: npx lerna bootstrap
+      - name: Figure out used package.json version
+        run: echo "PACKAGE_VERSION=$(node -p 'require("./package.json").version')" >> $GITHUB_ENV
+        shell: bash
       - name: Package recipes
         run: npm i && npm run package
         working-directory: ./recipes
@@ -263,7 +265,7 @@ jobs:
           npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=nightlies
           snapcraft logout
         shell: bash
-      - name: Build Ferdi with publish for 'release' branch
+      - name: Build Ferdi with publish for 'release' beta branch
         if: ${{ env.GIT_BRANCH_NAME == 'release' && contains(env.PACKAGE_VERSION, 'beta') }}
         env:
           GH_TOKEN: ${{ secrets.FERDI_PUBLISH_TOKEN }}
@@ -275,7 +277,7 @@ jobs:
           npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.channels=beta
           snapcraft logout
         shell: bash
-      - name: Build Ferdi with publish for 'release' branch
+      - name: Build Ferdi with publish for 'release' stable branch
         if: ${{ env.GIT_BRANCH_NAME == 'release' && !contains(env.PACKAGE_VERSION, 'beta') }}
         env:
           GH_TOKEN: ${{ secrets.FERDI_PUBLISH_TOKEN }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -63,7 +63,8 @@ linux:
 
 snap:
   publish:
-    provider: "snapStore"
+    - snapStore
+    - github
 
 nsis:
   perMachine: false


### PR DESCRIPTION
#### Description of Change
Fixes `PACKAGE_VERSION` env being empty and all release types go into the correct channel on snapcraft now.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [X] `npm test` passes
- [X] I tested/previewed my changes locally
