### PR TITLE
Fix issue with shortcut accelerators not working on macos where symbols were used for shift/alt keys

### DIFF
--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -10,7 +10,7 @@ import ms from 'ms';
 
 import { observable, autorun } from 'mobx';
 import ServiceModel from '../../../models/Service';
-import { shortcutKey } from '../../../environment';
+import { cmdOrCtrlShortcutKey } from '../../../environment';
 
 const IS_SERVICE_DEBUGGING_ENABLED = (
   localStorage.getItem('debug') || ''
@@ -201,7 +201,7 @@ class TabItem extends Component {
       {
         label: intl.formatMessage(messages.reload),
         click: reload,
-        accelerator: `${shortcutKey()}+R`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+R`,
       },
       {
         label: intl.formatMessage(messages.edit),
@@ -307,7 +307,7 @@ class TabItem extends Component {
         onClick={clickHandler}
         onContextMenu={() => menu.popup(getCurrentWindow())}
         data-tip={`${service.name} ${
-          shortcutIndex <= 9 ? `(${shortcutKey(false)}+${shortcutIndex})` : ''
+          shortcutIndex <= 9 ? `(${cmdOrCtrlShortcutKey(false)}+${shortcutIndex})` : ''
         }`}
       >
         <img src={service.icon} className="tab-item__icon" alt="" />

--- a/src/environment.js
+++ b/src/environment.js
@@ -79,17 +79,17 @@ export const is64Bit = osArch.match(/64/);
 const ctrlKey = isMac ? '⌘' : 'Ctrl';
 const cmdKey = isMac ? 'Cmd' : 'Ctrl';
 
-export const altKey = isMac ? '⌥' : 'Alt';
-export const shiftKey = isMac ? '⇧' : 'Shift';
+export const altKey = (isAccelerator = true) => (!isAccelerator && isMac ? '⌥' : 'Alt');
+export const shiftKey = (isAccelerator = true) => (!isAccelerator && isMac ? '⇧' : 'Shift');
 
 // Platform specific shortcut keys
-export const shortcutKey = (isAccelerator = true) => (isAccelerator ? cmdKey : ctrlKey);
-export const lockFerdiShortcutKey = (isAccelerator = true) => `${shortcutKey(isAccelerator)}+${shiftKey}+L`;
-export const todosToggleShortcutKey = (isAccelerator = true) => `${shortcutKey(isAccelerator)}+T`;
-export const workspaceToggleShortcutKey = (isAccelerator = true) => `${shortcutKey(isAccelerator)}+D`;
-export const muteFerdiShortcutKey = (isAccelerator = true) => `${shortcutKey(isAccelerator)}+${shiftKey}+M`;
-export const addNewServiceShortcutKey = (isAccelerator = true) => `${shortcutKey(isAccelerator)}+N`;
-export const settingsShortcutKey = (isAccelerator = true) => `${shortcutKey(isAccelerator)}+${isMac ? ',' : 'P'}`;
+export const cmdOrCtrlShortcutKey = (isAccelerator = true) => (isAccelerator ? cmdKey : ctrlKey);
+export const lockFerdiShortcutKey = (isAccelerator = true) => `${cmdOrCtrlShortcutKey(isAccelerator)}+${shiftKey(isAccelerator)}+L`;
+export const todosToggleShortcutKey = (isAccelerator = true) => `${cmdOrCtrlShortcutKey(isAccelerator)}+T`;
+export const workspaceToggleShortcutKey = (isAccelerator = true) => `${cmdOrCtrlShortcutKey(isAccelerator)}+D`;
+export const muteFerdiShortcutKey = (isAccelerator = true) => `${cmdOrCtrlShortcutKey(isAccelerator)}+${shiftKey(isAccelerator)}+M`;
+export const addNewServiceShortcutKey = (isAccelerator = true) => `${cmdOrCtrlShortcutKey(isAccelerator)}+N`;
+export const settingsShortcutKey = (isAccelerator = true) => `${cmdOrCtrlShortcutKey(isAccelerator)}+${isMac ? ',' : 'P'}`;
 
 let api;
 let wsApi;

--- a/src/features/workspaces/components/WorkspaceDrawerItem.js
+++ b/src/features/workspaces/components/WorkspaceDrawerItem.js
@@ -5,7 +5,7 @@ import { observer } from 'mobx-react';
 import injectSheet from 'react-jss';
 import classnames from 'classnames';
 import { defineMessages, intlShape } from 'react-intl';
-import { altKey, shortcutKey } from '../../../environment';
+import { altKey, cmdOrCtrlShortcutKey } from '../../../environment';
 
 const messages = defineMessages({
   noServicesAddedYet: {
@@ -125,7 +125,7 @@ class WorkspaceDrawerItem extends Component {
           onContextMenuEditClick && contextMenu.popup(getCurrentWindow())
         }
         data-tip={`${
-          shortcutIndex <= 9 ? `(${shortcutKey(false)}+${altKey}+${shortcutIndex})` : ''
+          shortcutIndex <= 9 ? `(${cmdOrCtrlShortcutKey(false)}+${altKey(false)}+${shortcutIndex})` : ''
         }`}
       >
         <span

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -4,7 +4,7 @@ import { autorun, observable } from 'mobx';
 import { defineMessages } from 'react-intl';
 import { CUSTOM_WEBSITE_RECIPE_ID, GITHUB_FERDI_URL, LIVE_API_FERDI_WEBSITE } from '../config';
 import {
-  shortcutKey, altKey, shiftKey, settingsShortcutKey, isLinux, isMac, aboutAppDetails, lockFerdiShortcutKey, todosToggleShortcutKey, workspaceToggleShortcutKey, addNewServiceShortcutKey, muteFerdiShortcutKey,
+  cmdOrCtrlShortcutKey, altKey, shiftKey, settingsShortcutKey, isLinux, isMac, aboutAppDetails, lockFerdiShortcutKey, todosToggleShortcutKey, workspaceToggleShortcutKey, addNewServiceShortcutKey, muteFerdiShortcutKey,
 } from '../environment';
 import { announcementsStore } from '../features/announcements';
 import { announcementActions } from '../features/announcements/actions';
@@ -317,7 +317,7 @@ function getActiveWebview() {
 const _titleBarTemplateFactory = (intl, locked) => [
   {
     label: intl.formatMessage(menuItems.edit),
-    accelerator: `${altKey}+E`,
+    accelerator: `${altKey()}+E`,
     submenu: [
       {
         label: intl.formatMessage(menuItems.undo),
@@ -332,22 +332,22 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.cut),
-        accelerator: `${shortcutKey()}+X`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+X`,
         role: 'cut',
       },
       {
         label: intl.formatMessage(menuItems.copy),
-        accelerator: `${shortcutKey()}+C`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+C`,
         role: 'copy',
       },
       {
         label: intl.formatMessage(menuItems.paste),
-        accelerator: `${shortcutKey()}+V`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+V`,
         role: 'paste',
       },
       {
         label: intl.formatMessage(menuItems.pasteAndMatchStyle),
-        accelerator: `${shortcutKey()}+${shiftKey}+V`, // Override the accelerator since this adds new key combo in macos
+        accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+V`, // Override the accelerator since this adds new key combo in macos
         role: 'pasteAndMatchStyle',
         click() {
           getActiveWebview().pasteAndMatchStyle();
@@ -359,14 +359,14 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.selectAll),
-        accelerator: `${shortcutKey()}+A`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+A`,
         role: 'selectall',
       },
     ],
   },
   {
     label: intl.formatMessage(menuItems.view),
-    accelerator: `${altKey}+V`,
+    accelerator: `${altKey()}+V`,
     visible: !locked,
     submenu: [
       {
@@ -374,7 +374,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.openQuickSwitch),
-        accelerator: `${shortcutKey()}+S`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+S`,
         click() {
           window.ferdi.features.quickSwitch.state.isModalVisible = true;
         },
@@ -384,7 +384,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.findInPage),
-        accelerator: `${shortcutKey()}+F`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+F`,
         click() {
           // Check if there is a service active
           if (!window.ferdi.stores.services.active) return;
@@ -405,14 +405,14 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.back),
-        accelerator: `${shortcutKey()}+Left`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+Left`,
         click() {
           getActiveWebview().goBack();
         },
       },
       {
         label: intl.formatMessage(menuItems.forward),
-        accelerator: `${shortcutKey()}+Right`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+Right`,
         click() {
           getActiveWebview().goForward();
         },
@@ -422,7 +422,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.resetZoom),
-        accelerator: `${shortcutKey()}+0`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+0`,
         role: 'resetZoom',
         click() {
           getActiveWebview().setZoomLevel(0);
@@ -430,7 +430,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.zoomIn),
-        accelerator: `${shortcutKey()}+plus`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+plus`,
         role: 'zoomIn',
         click() {
           const activeService = getActiveWebview();
@@ -442,7 +442,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       },
       {
         label: intl.formatMessage(menuItems.zoomOut),
-        accelerator: `${shortcutKey()}+-`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+-`,
         role: 'zoomOut',
         click() {
           const activeService = getActiveWebview();
@@ -462,7 +462,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
       {
         label: intl.formatMessage(menuItems.toggleDarkMode),
         type: 'checkbox',
-        accelerator: `${shortcutKey()}+${shiftKey}+D`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+D`,
         checked: window.ferdi.stores.settings.app.darkMode,
         click: () => {
           window.ferdi.actions.settings.update({
@@ -477,13 +477,13 @@ const _titleBarTemplateFactory = (intl, locked) => [
   },
   {
     label: intl.formatMessage(menuItems.services),
-    accelerator: `${altKey}+S`,
+    accelerator: `${altKey()}+S`,
     visible: !locked,
     submenu: [],
   },
   {
     label: intl.formatMessage(menuItems.workspaces),
-    accelerator: `${altKey}+W`,
+    accelerator: `${altKey()}+W`,
     submenu: [],
     visible: !locked && workspaceStore.isFeatureEnabled,
   },
@@ -508,7 +508,7 @@ const _titleBarTemplateFactory = (intl, locked) => [
   },
   {
     label: intl.formatMessage(menuItems.help),
-    accelerator: `${altKey}+H`,
+    accelerator: `${altKey()}+H`,
     role: 'help',
     submenu: [
       {
@@ -611,13 +611,13 @@ export default class FranzMenu {
         type: 'separator',
       }, {
         label: intl.formatMessage(menuItems.toggleDevTools),
-        accelerator: `${shortcutKey()}+${altKey}+I`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${altKey()}+I`,
         click: (menuItem, browserWindow) => {
           browserWindow.webContents.toggleDevTools();
         },
       }, {
         label: intl.formatMessage(menuItems.toggleServiceDevTools),
-        accelerator: `${shortcutKey()}+${shiftKey}+${altKey}+I`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+${altKey()}+I`,
         click: () => {
           this.actions.service.openDevToolsForActiveService();
         },
@@ -627,7 +627,7 @@ export default class FranzMenu {
       if (this.stores.features.features.isTodosEnabled) {
         tpl[1].submenu.push({
           label: intl.formatMessage(menuItems.toggleTodosDevTools),
-          accelerator: `${shortcutKey()}+${shiftKey}+${altKey}+O`,
+          accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+${altKey()}+O`,
           click: () => {
             const webview = document.querySelector('#todos-panel webview');
             if (webview) this.actions.todos.openDevTools();
@@ -638,7 +638,7 @@ export default class FranzMenu {
       tpl[1].submenu.unshift({
         label: intl.formatMessage(menuItems.reloadService),
         id: 'reloadService', // TODO: needed?
-        accelerator: `${shortcutKey()}+R`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+R`,
         click: () => {
           if (this.stores.user.isLoggedIn
           && this.stores.services.enabled.length > 0) {
@@ -653,13 +653,13 @@ export default class FranzMenu {
         },
       }, {
         label: intl.formatMessage(menuItems.reloadFerdi),
-        accelerator: `${shortcutKey()}+${shiftKey}+R`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+R`,
         click: () => {
           window.location.reload();
         },
       }, {
         label: intl.formatMessage(menuItems.reloadTodos),
-        accelerator: `${shortcutKey()}+${shiftKey}+${altKey}+R`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+${altKey()}+R`,
         click: () => {
           this.actions.todos.reload();
         },
@@ -715,7 +715,7 @@ export default class FranzMenu {
 
     tpl.unshift({
       label: isMac ? app.name : intl.formatMessage(menuItems.file),
-      accelerator: `${altKey}+F`,
+      accelerator: `${altKey()}+F`,
       submenu: [
         {
           label: intl.formatMessage(menuItems.about),
@@ -831,7 +831,7 @@ export default class FranzMenu {
         {
           label: intl.formatMessage(menuItems.quit),
           role: 'quit',
-          accelerator: `${shortcutKey()}+Q`,
+          accelerator: `${cmdOrCtrlShortcutKey()}+Q`,
           click() {
             app.quit();
           },
@@ -882,22 +882,22 @@ export default class FranzMenu {
       type: 'separator',
     }, {
       label: intl.formatMessage(menuItems.activateNextService),
-      accelerator: `${shortcutKey()}+tab`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+tab`,
       click: () => this.actions.service.setActiveNext(),
       visible: !cmdAltShortcutsVisibile,
     }, {
       label: intl.formatMessage(menuItems.activateNextService),
-      accelerator: `${shortcutKey()}+${altKey}+right`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+${altKey()}+right`,
       click: () => this.actions.service.setActiveNext(),
       visible: cmdAltShortcutsVisibile,
     }, {
       label: intl.formatMessage(menuItems.activatePreviousService),
-      accelerator: `${shortcutKey()}+${shiftKey}+tab`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+tab`,
       click: () => this.actions.service.setActivePrev(),
       visible: !cmdAltShortcutsVisibile,
     }, {
       label: intl.formatMessage(menuItems.activatePreviousService),
-      accelerator: `${shortcutKey()}+${altKey}+left`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+${altKey()}+left`,
       click: () => this.actions.service.setActivePrev(),
       visible: cmdAltShortcutsVisibile,
     }, {
@@ -912,7 +912,7 @@ export default class FranzMenu {
 
     services.allDisplayed.forEach((service, i) => (menu.push({
       label: this._getServiceName(service),
-      accelerator: i < 9 ? `${shortcutKey()}+${i + 1}` : null,
+      accelerator: i < 9 ? `${cmdOrCtrlShortcutKey()}+${i + 1}` : null,
       type: 'radio',
       checked: service.isActive,
       click: () => {
@@ -929,7 +929,7 @@ export default class FranzMenu {
         type: 'separator',
       }, {
         label: intl.formatMessage(menuItems.serviceGoHome),
-        accelerator: `${shortcutKey()}+${shiftKey}+H`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+H`,
         click: () => this.actions.service.reloadActive(),
       });
     }
@@ -945,7 +945,7 @@ export default class FranzMenu {
     // Add new workspace item:
     menu.push({
       label: intl.formatMessage(menuItems.addNewWorkspace),
-      accelerator: `${shortcutKey()}+${shiftKey}+N`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+N`,
       click: () => {
         workspaceActions.openWorkspaceSettings();
       },
@@ -974,7 +974,7 @@ export default class FranzMenu {
     // Default workspace
     menu.push({
       label: intl.formatMessage(menuItems.defaultWorkspace),
-      accelerator: `${shortcutKey()}+${altKey}+0`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+${altKey()}+0`,
       type: 'radio',
       checked: !activeWorkspace,
       click: () => {
@@ -985,7 +985,7 @@ export default class FranzMenu {
     // Workspace items
     workspaces.forEach((workspace, i) => menu.push({
       label: workspace.name,
-      accelerator: i < 9 ? `${shortcutKey()}+${altKey}+${i + 1}` : null,
+      accelerator: i < 9 ? `${cmdOrCtrlShortcutKey()}+${altKey()}+${i + 1}` : null,
       type: 'radio',
       checked: activeWorkspace ? workspace.id === activeWorkspace.id : false,
       click: () => {

--- a/src/webview/contextMenuBuilder.js
+++ b/src/webview/contextMenuBuilder.js
@@ -8,7 +8,7 @@
  */
 import { clipboard, ipcRenderer, nativeImage } from 'electron';
 import { Menu, MenuItem } from '@electron/remote';
-import { shortcutKey, isMac } from '../environment';
+import { cmdOrCtrlShortcutKey, isMac } from '../environment';
 
 import { SEARCH_ENGINE_NAMES, SEARCH_ENGINE_URLS } from '../config';
 import { openExternalUrl } from '../helpers/url-helpers';
@@ -375,7 +375,7 @@ module.exports = class ContextMenuBuilder {
     const webContents = this.getWebContents();
     menu.append(new MenuItem({
       label: this.stringTable.cut(),
-      accelerator: `${shortcutKey()}+X`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+X`,
       enabled: menuInfo.editFlags.canCut,
       click: () => webContents.cut(),
     }));
@@ -390,7 +390,7 @@ module.exports = class ContextMenuBuilder {
     const webContents = this.getWebContents();
     menu.append(new MenuItem({
       label: this.stringTable.copy(),
-      accelerator: `${shortcutKey()}+C`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+C`,
       enabled: menuInfo.editFlags.canCopy,
       click: () => webContents.copy(),
     }));
@@ -405,7 +405,7 @@ module.exports = class ContextMenuBuilder {
     const webContents = this.getWebContents();
     menu.append(new MenuItem({
       label: this.stringTable.paste(),
-      accelerator: `${shortcutKey()}+V`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+V`,
       enabled: menuInfo.editFlags.canPaste,
       click: () => webContents.paste(),
     }));
@@ -423,7 +423,7 @@ module.exports = class ContextMenuBuilder {
       menu.append(
         new MenuItem({
           label: this.stringTable.pasteAndMatchStyle(),
-          accelerator: `${shortcutKey()}+Shift+V`,
+          accelerator: `${cmdOrCtrlShortcutKey()}+Shift+V`,
           click: () => webContents.pasteAndMatchStyle(),
         }),
       );
@@ -489,7 +489,7 @@ module.exports = class ContextMenuBuilder {
     const webContents = this.getWebContents();
     menu.append(new MenuItem({
       label: this.stringTable.goBack(),
-      accelerator: `${shortcutKey()}+left`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+left`,
       enabled: webContents.canGoBack(),
       click: () => webContents.goBack(),
     }));
@@ -504,7 +504,7 @@ module.exports = class ContextMenuBuilder {
     const webContents = this.getWebContents();
     menu.append(new MenuItem({
       label: this.stringTable.goForward(),
-      accelerator: `${shortcutKey()}+right`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+right`,
       enabled: webContents.canGoForward(),
       click: () => webContents.goForward(),
     }));
@@ -535,7 +535,7 @@ module.exports = class ContextMenuBuilder {
     const baseURL = new URL(menuInfo.pageURL);
     menu.append(new MenuItem({
       label: this.stringTable.goToHomePage(),
-      accelerator: `${shortcutKey()}+Home`,
+      accelerator: `${cmdOrCtrlShortcutKey()}+Home`,
       enabled: true,
       click: () => {
         // webContents.loadURL(baseURL.origin);


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
A previous refactoring accidentally ended up showing the symbol for the `alt` and `shift` keys - but, on macos, using symbol for the shortcut key accelerator disables the accelerator and also doesn't show it visually in the menu.

#### Motivation and Context
Fixing Ferdi to behave as before. This is key for users who have setup a password lock and/or need to refresh Ferdi as a whole or any individual services.

#### Screenshots
<img width="303" alt="Screenshot 2021-08-15 at 8 35 36 PM" src="https://user-images.githubusercontent.com/69629/129483065-1c707bb7-9227-4bcd-ad83-275cf50cd5e7.png">
Wherever the shortcut had an `Alt` key or a `Shift` key - those were previously missing and now should show up.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Fix menu shortcut keys on macos where they were referring to `Alt` and/or `Shift` in the combination.
