### PR TITLE
build: fix snap asset on GitHub

### DIFF
--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -262,7 +262,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
-          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=nightlies
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=nightlies -c.snap.publish.repo=nightlies -c.snap.publish.releaseType=prerelease -c.snap.publish.channels=edge
           snapcraft logout
         shell: bash
       - name: Build Ferdi with publish for 'release' beta branch
@@ -274,7 +274,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
-          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.channels=beta
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.repo=ferdi -c.snap.publish.releaseType=prerelease -c.snap.publish.channels=beta
           snapcraft logout
         shell: bash
       - name: Build Ferdi with publish for 'release' stable branch
@@ -286,7 +286,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
-          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.channels=stable
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.repo=ferdi -c.snap.publish.releaseType=release -c.snap.publish.channels=stable
           snapcraft logout
         shell: bash
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,9 +64,7 @@ linux:
 snap:
   publish:
     - snapStore
-    - provider: github
-      repo: "https://github.com/getferdi/nightlies.git"
-      releaseType: prerelease
+    - github
 
 nsis:
   perMachine: false

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -64,7 +64,9 @@ linux:
 snap:
   publish:
     - snapStore
-    - github
+    - provider: github
+      repo: "https://github.com/getferdi/nightlies.git"
+      releaseType: prerelease
 
 nsis:
   perMachine: false


### PR DESCRIPTION
#### Description of Change
- specify repository and releaseType for snap GitHub publish

#### Motivation and Context
Currently snap asset lands in https://github.com/getferdi/ferdi/releases, which is wrong. With the new config it should be released in nightlies, together with the other assets.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [ ] I tested/previewed my changes locally