### PR TITLE
build: fix snap release to snapstore only

### DIFF
--- a/.github/workflows/ferdi-builds.yml
+++ b/.github/workflows/ferdi-builds.yml
@@ -262,7 +262,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
-          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=nightlies -c.snap.publish.repo=nightlies -c.snap.publish.releaseType=prerelease -c.snap.publish.channels=edge
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=nightlies -c.snap.publish.provider=snapStore -c.snap.publish.repo=nightlies -c.snap.publish.channels=edge
           snapcraft logout
         shell: bash
       - name: Build Ferdi with publish for 'release' beta branch
@@ -274,7 +274,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
-          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.repo=ferdi -c.snap.publish.releaseType=prerelease -c.snap.publish.channels=beta
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.provider=snapStore -c.snap.publish.repo=ferdi -c.snap.publish.channels=beta
           snapcraft logout
         shell: bash
       - name: Build Ferdi with publish for 'release' stable branch
@@ -286,7 +286,7 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           echo "$SNAPCRAFT_LOGIN" | snapcraft login --with -
-          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.repo=ferdi -c.snap.publish.releaseType=release -c.snap.publish.channels=stable
+          npm run build -- --publish always -c.publish.provider=github -c.publish.owner=${{ github.repository_owner }} -c.publish.repo=ferdi -c.snap.publish.provider=snapStore -c.snap.publish.repo=ferdi -c.snap.publish.channels=stable
           snapcraft logout
         shell: bash
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -61,11 +61,6 @@ linux:
     - target: freebsd
     - target: snap
 
-snap:
-  publish:
-    - snapStore
-    - github
-
 nsis:
   perMachine: false
   oneClick: true


### PR DESCRIPTION
#### Description of Change
- removed snap configuration from electron-builder.yml
- specified repo and provider explicitly in ferdi-builds.yml

#### Motivation and Context
Linux builds were breaking due to misconfigured snap configuration.
We decided to only publish to snapstore and not on github assets to simplify the config.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally