### PR TITLE
Check if default app protocol fix is set before setting it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -388,11 +388,9 @@ app.on('ready', () => {
   enforceMacOSAppLocation();
 
   // Register App URL
-  if (isDevMode) {
-    app.setAsDefaultProtocolClient('ferdi-dev');
-  } else {
-    app.setAsDefaultProtocolClient('ferdi');
-  }
+  if (!app.isDefaultProtocolClient(isDevMode ? 'ferdi-dev' : 'ferdi')) {
+    app.setAsDefaultProtocolClient(isDevMode ? 'ferdi-dev' : 'ferdi');
+  } 
 
   if (isWindows) {
     app.setUserTasks([

--- a/src/index.js
+++ b/src/index.js
@@ -388,8 +388,9 @@ app.on('ready', () => {
   enforceMacOSAppLocation();
 
   // Register App URL
-  if (!app.isDefaultProtocolClient(isDevMode ? 'ferdi-dev' : 'ferdi')) {
-    app.setAsDefaultProtocolClient(isDevMode ? 'ferdi-dev' : 'ferdi');
+  const protocolClient = isDevMode ? 'ferdi-dev' : 'ferdi');
+  if (!app.isDefaultProtocolClient(protocolClient) {
+    app.setAsDefaultProtocolClient(protocolClient);
   } 
 
   if (isWindows) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
This PR should fix the app always setting itself as the default protocol when it's not necessary to. On some operating systems (notably seen with linux) maybe rather has to do with snap in the referenced issue it closes it seems to always show a confirmation popup on every launch when the app is setting itself as a protocol client.

#### Motivation and Context
Closes https://github.com/getferdi/ferdi/issues/1817

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdi to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
