### PR TITLE
Incorrect position while adding a new service when there were pre-existing services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+# [v5.6.1-nightly.35](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.34...v5.6.1-nightly.35) (2021-08-22)
+
+- Remove checks that refers to paid subscription since Ferdi is always free 💖 @vraravam
+- Remove 'shareFranz' feature since its always turned off for Ferdi 💖 @vraravam
+
+### Bug Fixes
+
+- Incorrect position while adding a new service when there were pre-existing services (#1820) 💖 @vraravam
+
+### Internal
+
+- Typescript conversion 💖 @vraravam
+- Set stricter rules for typescript conversion 💖 @vraravam
+- Move build-time js files out of 'src' and into 'scripts' 💖 @vraravam
+
 # [v5.6.1-nightly.34](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.33...v5.6.1-nightly.34) (2021-08-21)
 
 ### Bug Fixes

--- a/src/config.ts
+++ b/src/config.ts
@@ -181,3 +181,5 @@ export const DEFAULT_IS_FEATURE_ENABLED_BY_USER = true;
 export const TODOS_PARTITION_ID = 'persist:todos';
 
 export const CUSTOM_WEBSITE_RECIPE_ID = 'franz-custom-website';
+
+export const DEFAULT_SERVICE_ORDER = 99; // something high enough that it gets added to the end of the already-added services on the left sidebar

--- a/src/internal-server/app/Controllers/Http/ServiceController.js
+++ b/src/internal-server/app/Controllers/Http/ServiceController.js
@@ -5,7 +5,7 @@ const Env = use('Env');
 const uuid = require('uuid/v4');
 const path = require('path');
 const fs = require('fs-extra');
-const { LOCAL_HOSTNAME } = require('../../../../config');
+const { LOCAL_HOSTNAME, DEFAULT_SERVICE_ORDER } = require('../../../../config');
 
 const hostname = LOCAL_HOSTNAME;
 const port = Env.get('PORT');
@@ -54,7 +54,7 @@ class ServiceController {
         isMuted: false,
         isDarkModeEnabled: '', // TODO: This should ideally be a boolean (false). But, changing it caused the sidebar toggle to not work.
         spellcheckerLanguage: '',
-        order: 1,
+        order: DEFAULT_SERVICE_ORDER,
         customRecipe: false,
         hasCustomIcon: false,
         workspaces: [],
@@ -83,7 +83,7 @@ class ServiceController {
         isEnabled: true,
         isMuted: false,
         isNotificationEnabled: true,
-        order: 1,
+        order: DEFAULT_SERVICE_ORDER,
         spellcheckerLanguage: '',
         workspaces: [],
         ...JSON.parse(service.settings),
@@ -257,7 +257,7 @@ class ServiceController {
         isEnabled: true,
         isMuted: false,
         isNotificationEnabled: true,
-        order: 1,
+        order: DEFAULT_SERVICE_ORDER,
         spellcheckerLanguage: '',
         workspaces: [],
         ...JSON.parse(service.settings),

--- a/src/models/Service.js
+++ b/src/models/Service.js
@@ -7,6 +7,7 @@ import { join } from 'path';
 import { todosStore } from '../features/todos';
 import { isValidExternalURL } from '../helpers/url-helpers';
 import UserAgent from './UserAgent';
+import { DEFAULT_SERVICE_ORDER } from '../config';
 
 const debug = require('debug')('Ferdi:Service');
 
@@ -31,7 +32,7 @@ export default class Service {
 
   @observable unreadIndirectMessageCount = 0;
 
-  @observable order = 99;
+  @observable order = DEFAULT_SERVICE_ORDER;
 
   @observable isEnabled = true;
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
previously, it used to always add at the position number 2. Now, the newly added service appears as the last service in the sidebar.


#### Motivation and Context
fixes #1445 

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdi to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
