### PR TITLE
Remove "stores.app.accentColor is marked as required" console error

### DIFF
--- a/src/components/ui/FullscreenLoader/index.js
+++ b/src/components/ui/FullscreenLoader/index.js
@@ -16,16 +16,6 @@ export default @inject('stores') @withTheme @injectSheet(styles) @observer class
     theme: PropTypes.object.isRequired,
     spinnerColor: PropTypes.string,
     children: PropTypes.node,
-    stores: PropTypes.shape({
-      app: PropTypes.shape({
-        accentColor: PropTypes.string.isRequired,
-      }).isRequired,
-      settings: PropTypes.shape({
-        app: PropTypes.shape({
-          accentColor: PropTypes.string.isRequired,
-        }).isRequired,
-      }).isRequired,
-    }).isRequired,
   };
 
   static defaultProps = {
@@ -42,16 +32,10 @@ export default @inject('stores') @withTheme @injectSheet(styles) @observer class
       spinnerColor,
       className,
       theme,
-      stores,
     } = this.props;
 
     return (
-      <div
-        className={classes.wrapper}
-        style={{
-          background: stores.app.accentColor,
-        }}
-      >
+      <div className={classes.wrapper}>
         <div
           className={classnames({
             [`${classes.component}`]: true,

--- a/src/components/ui/FullscreenLoader/index.js
+++ b/src/components/ui/FullscreenLoader/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { observer, inject } from 'mobx-react';
+import { observer } from 'mobx-react';
 import injectSheet, { withTheme } from 'react-jss';
 import classnames from 'classnames';
 
@@ -8,7 +8,7 @@ import Loader from '../Loader';
 
 import styles from './styles';
 
-export default @inject('stores') @withTheme @injectSheet(styles) @observer class FullscreenLoader extends Component {
+export default @withTheme @injectSheet(styles) @observer class FullscreenLoader extends Component {
   static propTypes = {
     className: PropTypes.string,
     title: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [X] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [X] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
`AccentColor` is stored in `stores.settings.app.accentColor`, but we use `stores.app.accentColor` in the code and the linter has added `stores.app.accentColor` as required.
I didn't replace `stores.app.accentColor` by `stores.settings.app.accentColor` because it change default black background by purple (or accentColor) background on the loader screen (when you start Ferdi) this is not very beautiful.

#### Motivation and Context
Remove Console error and cleanup unused code
Fix: #1687

#### Checklist
- [X] My pull request is properly named
- [X] The changes respect the code style of the project (`npm run prepare-code`)
- [X] `npm test` passes
- [X] I tested/previewed my changes locally

