### PR TITLE
Expose some functions to the recipe child processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [v5.6.1-nightly.51](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.50...v5.6.1-nightly.51) (2021-09-06)
+
+### Internal
+
+- Remove dependency of recipes requiring `electron` and `electron/remote` modules (#1869 & getferdi/recipes#674) 💖 @vraravam
+
 # [v5.6.1-nightly.50](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.48...v5.6.1-nightly.50) (2021-09-05)
 
 ### Bug Fixes

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -1,5 +1,6 @@
 /* eslint-disable import/first */
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge, desktopCapturer, ipcRenderer } from 'electron';
+import { BrowserWindow, getCurrentWebContents } from '@electron/remote';
 import { join } from 'path';
 import { autorun, computed, observable } from 'mobx';
 import { pathExistsSync, readFileSync } from 'fs-extra';
@@ -107,6 +108,11 @@ contextBridge.exposeInMainWorld('ferdi', {
   displayNotification: (title, options) =>
     notificationsHandler.displayNotification(title, options),
   getDisplayMediaSelector,
+  getCurrentWebContents,
+  BrowserWindow,
+  ipcRenderer,
+  // TODO: When the discord recipe is changed to use the screenshare.js, this can be removed
+  desktopCapturer,
 });
 
 ipcRenderer.sendToHost(

--- a/src/webview/spellchecker.ts
+++ b/src/webview/spellchecker.ts
@@ -4,8 +4,8 @@ import { DEFAULT_APP_SETTINGS, isMac } from '../environment';
 
 const debug = require('debug')('Ferdi:spellchecker');
 
-const webContents = getCurrentWebContents();
-const [defaultLocale] = webContents.session.getSpellCheckerLanguages();
+const { session } = getCurrentWebContents();
+const [defaultLocale] = session.getSpellCheckerLanguages();
 debug('Spellchecker default locale is', defaultLocale);
 
 export function getSpellcheckerLocaleByFuzzyIdentifier(identifier: string) {
@@ -31,5 +31,5 @@ export function switchDict(locale: string) {
 
   locales.push(defaultLocale, DEFAULT_APP_SETTINGS.fallbackLocale);
 
-  webContents.session.setSpellCheckerLanguages(locales);
+  session.setSpellCheckerLanguages(locales);
 }


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Need to remove the need for recipes to require either `electron` and/or `@electron/remote` modules.

#### Motivation and Context
By these changes, we are exposing the objects/functions that the recipes need so that they can be used without the recipe needing to `require` these npm modules.

#### Screenshots
<!-- Remove the section if this does not apply. -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdi to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
