### PR TITLE
fix: sidebar context menu not synced when toggling via the context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # [v5.6.1-nightly.51](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.50...v5.6.1-nightly.51) (2021-09-06)
 
+### Bug Fixes
+
+- Fix sidebar context menu not synced when toggling via the context menu (#1871) 💖 @sad270
+
 ### Internal
 
 - Remove dependency of recipes requiring `electron` and `electron/remote` modules (#1869 & getferdi/recipes#674) 💖 @vraravam

--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -227,8 +227,8 @@ class TabItem extends Component {
       },
       {
         label: service.isDarkModeEnabled
-          ? intl.formatMessage(messages.enableDarkMode)
-          : intl.formatMessage(messages.disableDarkMode),
+          ? intl.formatMessage(messages.disableDarkMode)
+          : intl.formatMessage(messages.enableDarkMode),
         click: () => toggleDarkMode(),
       },
       {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -910,7 +910,6 @@ export default class ServicesStore extends Store {
 
   @action _toggleNotifications({ serviceId }) {
     const service = this.one(serviceId);
-    service.isNotificationEnabled = !service.isNotificationEnabled;
 
     this.actions.service.updateService({
       serviceId,
@@ -923,7 +922,6 @@ export default class ServicesStore extends Store {
 
   @action _toggleAudio({ serviceId }) {
     const service = this.one(serviceId);
-    service.isMuted = !service.isMuted;
 
     this.actions.service.updateService({
       serviceId,
@@ -936,7 +934,6 @@ export default class ServicesStore extends Store {
 
   @action _toggleDarkMode({ serviceId }) {
     const service = this.one(serviceId);
-    service.isDarkModeEnabled = !service.isDarkModeEnabled;
 
     this.actions.service.updateService({
       serviceId,


### PR DESCRIPTION
#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [X] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [X] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
* Invert Dark mode toggle action label in menu item (Before he was displayed "Enable Dark mode" when Dark mode is already enabled, now he display "Disable Dark mode" when dark mode is enabled)
* Toggle DarkMode, Audio and Notification on click

It's doesn't work because he toggle twice the setting, he toggle :
* First time when `service.isDarkModeEnabled = !service.isDarkModeEnabled;`
* Second time in `this.actions.service.updateService`

The double toggle was added in this PR #1823 
I remove the first toggle, and it's work on context menu AND in edit service too. So no need to toggle to time the settings, it seems to be a mistake @vraravam you can check that there is no regression ?

#### Motivation and Context
#1772


#### Checklist
- [X] My pull request is properly named
- [X] The changes respect the code style of the project (`npm run prepare-code`)
- [X] `npm test` passes
- [X] I tested/previewed my changes locally

#### Release Notes
Fix: sidebar context menu not synced when toggling statuses
