### PR TITLE
Fix zoom actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix issue while importing exported `ferdi.data` file while switching from one laptop to another when it had workspaces (#1874) 💖 @vraravam
 - Fix for 'Support' link not working (404 error) (#1806) 💖 @kytwb
+- Fix zoom actions executed on another services (#1867) 💖 @sad270
 
 # [v5.6.1-nightly.51](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.50...v5.6.1-nightly.51) (2021-09-06)
 

--- a/src/lib/Menu.js
+++ b/src/lib/Menu.js
@@ -362,9 +362,6 @@ const _titleBarTemplateFactory = (intl, locked) => [
         label: intl.formatMessage(menuItems.pasteAndMatchStyle),
         accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+V`, // Override the accelerator since this adds new key combo in macos
         role: 'pasteAndMatchStyle',
-        click() {
-          getActiveService().webview.pasteAndMatchStyle();
-        },
       },
       {
         label: intl.formatMessage(menuItems.delete),
@@ -438,7 +435,6 @@ const _titleBarTemplateFactory = (intl, locked) => [
       {
         label: intl.formatMessage(menuItems.resetZoom),
         accelerator: `${cmdOrCtrlShortcutKey()}+0`,
-        role: 'resetZoom',
         click() {
           this.actions.service.zoomResetForActiveService();
         },
@@ -446,7 +442,6 @@ const _titleBarTemplateFactory = (intl, locked) => [
       {
         label: intl.formatMessage(menuItems.zoomIn),
         accelerator: `${cmdOrCtrlShortcutKey()}+plus`,
-        role: 'zoomIn',
         click() {
           this.actions.service.zoomInForActiveService();
         },
@@ -454,7 +449,6 @@ const _titleBarTemplateFactory = (intl, locked) => [
       {
         label: intl.formatMessage(menuItems.zoomOut),
         accelerator: `${cmdOrCtrlShortcutKey()}+-`,
-        role: 'zoomOut',
         click() {
           this.actions.service.zoomOutForActiveService();
         },


### PR DESCRIPTION
#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [X] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this proect.
- [X] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [X] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
`role` override the `click` callback with the electron default action.
We should not have role AND click action. I don't know why the default role of zoom's actions change the zoom of another service, maybe he change a "global zoom" of all ferdi and this zoom affect only the first loaded services ? idk. But removing role on this action fix the bug.
I also remove the click action of `pasteAndMatchStyle`, because role seems to work good for this

#### Motivation and Context
#1867

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] My pull request is properly named
- [X] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [X] I tested/previewed my changes locally

#### Release Notes
Fix zoom actions
