### PR TITLE
fix: macOS black screen when close to systray in fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Add a confirmation dialog and a preference while quitting Ferdi (#1879) 💖 @vraravam
 
+### Bug Fixes
+
+- Fix macOS black screen when close to systray in fullscreen mode (#1878) 💖 @sad270
+
 # [v5.6.1-nightly.52](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.51...v5.6.1-nightly.52) (2021-09-07)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Fix macOS black screen when close to systray in fullscreen mode (#1878) 💖 @sad270
+- Fix macOS black screen when closing to systray in fullscreen mode (#1878) 💖 @sad270
 
 # [v5.6.1-nightly.52](https://github.com/getferdi/ferdi/compare/v5.6.1-nightly.51...v5.6.1-nightly.52) (2021-09-07)
 

--- a/src/index.js
+++ b/src/index.js
@@ -280,6 +280,11 @@ const createWindow = () => {
           debug('Skip taskbar: true');
           mainWindow.setSkipTaskbar(true);
         }
+      } else if (isMac && mainWindow.isFullScreen()) {
+        debug('Window: leaveFullScreen and hide');
+        mainWindow.once('show', () => mainWindow.setFullScreen(true));
+        mainWindow.once('leave-full-screen', () => mainWindow.hide());
+        mainWindow.setFullScreen(false);
       } else {
         debug('Window: hide');
         mainWindow.hide();


### PR DESCRIPTION
#### Pre-flight Checklist

1. Please remember that if you are logging a bug for some service that has *stopped working* or is *working incorrectly*, please log the bug [here](https://github.com/getferdi/recipes/issues)
2. If you are requesting support for a **new service** in Ferdi, please log it [here](https://github.com/getferdi/recipes/pulls)
3. Please remember to read the [self-help documentation](https://github.com/getferdi/ferdi#troubleshooting-recipes-self-help) - in case it helps you unblock yourself for issues related to older versions of recipes that were installed on your machine. (These will get automatically upgraded when you upgrade to the newer versions of Ferdi, but to get new recipes between Ferdi releases, this documentation is quite useful.)
4. Please consider supporting Ferdi!
  👉  https://github.com/sponsors/getferdi
  👉  https://opencollective.com/getferdi/donate
5. Please ensure you've completed all of the following.
- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Leave fullscreen before hide Ferdi, and enter in fullscreen when Ferdi was hidden in fullscreen.

#### Motivation and Context
fix #1878

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [X] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
Fix macOS black screen when close to systray in fullscreen mode
