### PR TITLE
chore: preconditions for pnpm migration

### DIFF
--- a/electron-builder.env
+++ b/electron-builder.env
@@ -1,0 +1,1 @@
+BUNDLING=true

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -149,6 +149,12 @@ export function mvLernaPackages() {
   return gulp.src(['packages/**']).pipe(gulp.dest(`${paths.dest}/packages`));
 }
 
+export function mvPostinstallScript() {
+  return gulp
+    .src(['./scripts/postinstall.js'])
+    .pipe(gulp.dest(`${paths.dest}/scripts`));
+}
+
 export function exportBuildInfo() {
   const buildInfoData = {
     timestamp: buildInfo.timestamp,
@@ -208,12 +214,7 @@ export function styles() {
 
 export function processJavascripts() {
   return gulp
-    .src(
-      [
-        paths.javascripts.src,
-      ],
-      { since: gulp.lastRun(processJavascripts) },
-    )
+    .src([paths.javascripts.src], { since: gulp.lastRun(processJavascripts) })
     .pipe(
       babel({
         comments: false,
@@ -226,15 +227,9 @@ export function processJavascripts() {
 
 export function processTypescripts() {
   return gulp
-    .src(
-      [
-        paths.typescripts.src,
-      ],
-      { since: gulp.lastRun(processTypescripts) },
-    )
+    .src([paths.typescripts.src], { since: gulp.lastRun(processTypescripts) })
     .pipe(tsProject())
-    .js
-    .pipe(
+    .js.pipe(
       babel({
         comments: false,
       }),
@@ -275,8 +270,21 @@ export function recipeInfo() {
 
 const build = gulp.series(
   clean,
-  gulp.parallel(mvSrc, mvPackageJson, mvLernaPackages, exportBuildInfo),
-  gulp.parallel(html, processJavascripts, processTypescripts, styles, recipes, recipeInfo),
+  gulp.parallel(
+    mvSrc,
+    mvPackageJson,
+    mvLernaPackages,
+    mvPostinstallScript,
+    exportBuildInfo,
+  ),
+  gulp.parallel(
+    html,
+    processJavascripts,
+    processTypescripts,
+    styles,
+    recipes,
+    recipeInfo,
+  ),
 );
 export { build };
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "engine-strict": true,
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "node scripts/prepare.js",
     "start": "electron ./build",
     "start:local": "cross-env USE_LOCAL_API=1 npm start",
     "start:live": "cross-env USE_LIVE_API=1 npm start",
@@ -35,7 +35,7 @@
     "reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write --require-pragma \"**/*.{js,jsx,scss}\"",
     "packages": "npx lerna publish --no-git-tag-version",
     "uidev": "cd uidev && webpack-dev-server",
-    "postinstall": "npx lerna run prepare",
+    "postinstall": "node scripts/postinstall.js",
     "apply-branding": "node ./src/i18n/apply-branding.js",
     "update-submodules": "git submodule update --remote --force",
     "prepare-code": "npm run lint && npm run reformat-files && npm run manage-translations && npm run apply-branding",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "dev": "tsc -w",
-    "prepare": "tsc"
+    "build": "tsc"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "dev": "tsc -w",
-    "prepare": "tsc",
+    "build": "tsc",
     "preprepare": "npm run test",
     "test": "npx mocha"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "dev": "tsc -w",
-    "prepare": "tsc"
+    "build": "tsc"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,8 @@
+const { exec } = require('child_process');
+
+// eslint-disable-next-line no-console
+const log = (err, stdout, stderr) => console.log(err || stdout || stderr);
+
+if (!process.env.BUNDLING) {
+  exec('npx lerna run build', log);
+}

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,0 +1,6 @@
+const isDev = process.env.NODE_ENV === 'development';
+
+if (isDev) {
+  // eslint-disable-next-line global-require
+  require('husky').install();
+}


### PR DESCRIPTION
#### Description of Change
- add electron-builder.env with bundling flag that is used to skip postinstall script
- rename prepare scripts to build to not accidentally trigger them in npm lifecycle
- skipping husky install in CI and prod environment properly now

#### Motivation and Context
We want to keep PR https://github.com/getferdi/ferdi/pull/1826 as small as possible, so these backwards compatible changes can be merged beforehand.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [ ] I tested/previewed my changes locally