### PR TITLE
Enable Split View Mode

### DIFF
--- a/src/components/services/content/ServiceView.js
+++ b/src/components/services/content/ServiceView.js
@@ -108,7 +108,7 @@ class ServiceView extends Component {
     }
 
     return (
-      <div className={webviewClasses}>
+      <div className={webviewClasses} data-name={service.name}>
         {service.isActive && service.isEnabled && (
           <>
             {service.hasCrashed && (

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -197,6 +197,7 @@ class EditSettingsForm extends Component {
     automaticUpdates: PropTypes.bool.isRequired,
     isDarkmodeEnabled: PropTypes.bool.isRequired,
     isAdaptableDarkModeEnabled: PropTypes.bool.isRequired,
+    isSplitModeEnabled: PropTypes.bool.isRequired,
     isNightlyEnabled: PropTypes.bool.isRequired,
     hasAddedTodosAsService: PropTypes.bool.isRequired,
     isOnline: PropTypes.bool.isRequired,
@@ -534,6 +535,10 @@ class EditSettingsForm extends Component {
                     </p>
                   </>
                 )}
+
+                <Hr />
+
+                <Toggle field={form.$('splitMode')} />
 
                 <Hr />
 

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -197,6 +197,7 @@ class EditSettingsForm extends Component {
     automaticUpdates: PropTypes.bool.isRequired,
     isDarkmodeEnabled: PropTypes.bool.isRequired,
     isAdaptableDarkModeEnabled: PropTypes.bool.isRequired,
+    isSplitModeEnabled: PropTypes.bool.isRequired,
     isNightlyEnabled: PropTypes.bool.isRequired,
     hasAddedTodosAsService: PropTypes.bool.isRequired,
     isOnline: PropTypes.bool.isRequired,

--- a/src/components/settings/settings/EditSettingsForm.js
+++ b/src/components/settings/settings/EditSettingsForm.js
@@ -197,7 +197,6 @@ class EditSettingsForm extends Component {
     automaticUpdates: PropTypes.bool.isRequired,
     isDarkmodeEnabled: PropTypes.bool.isRequired,
     isAdaptableDarkModeEnabled: PropTypes.bool.isRequired,
-    isSplitModeEnabled: PropTypes.bool.isRequired,
     isNightlyEnabled: PropTypes.bool.isRequired,
     hasAddedTodosAsService: PropTypes.bool.isRequired,
     isOnline: PropTypes.bool.isRequired,

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -694,6 +694,7 @@ class EditSettingsScreen extends Component {
           isAdaptableDarkModeEnabled={
             this.props.stores.settings.app.adaptableDarkMode
           }
+          isSplitModeEnabled={this.props.stores.settings.app.splitMode}
           isTodosActivated={this.props.stores.todos.isFeatureEnabledByUser}
           isUsingCustomTodoService={
             this.props.stores.todos.isUsingCustomTodoService

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -694,7 +694,6 @@ class EditSettingsScreen extends Component {
           isAdaptableDarkModeEnabled={
             this.props.stores.settings.app.adaptableDarkMode
           }
-          isSplitModeEnabled={this.props.stores.settings.app.splitMode}
           isTodosActivated={this.props.stores.todos.isFeatureEnabledByUser}
           isUsingCustomTodoService={
             this.props.stores.todos.isUsingCustomTodoService

--- a/src/containers/settings/EditSettingsScreen.js
+++ b/src/containers/settings/EditSettingsScreen.js
@@ -164,6 +164,10 @@ const messages = defineMessages({
     id: 'settings.app.form.universalDarkMode',
     defaultMessage: 'Enable universal Dark Mode',
   },
+  splitMode: {
+    id: 'settings.app.form.splitMode',
+    defaultMessage: 'Enable Split View Mode',
+  },
   serviceRibbonWidth: {
     id: 'settings.app.form.serviceRibbonWidth',
     defaultMessage: 'Sidebar width',
@@ -288,6 +292,7 @@ class EditSettingsScreen extends Component {
         darkMode: Boolean(settingsData.darkMode),
         adaptableDarkMode: Boolean(settingsData.adaptableDarkMode),
         universalDarkMode: Boolean(settingsData.universalDarkMode),
+        splitMode: Boolean(settingsData.splitMode),
         serviceRibbonWidth: Number(settingsData.serviceRibbonWidth),
         iconSize: Number(settingsData.iconSize),
         useVerticalStyle: Boolean(settingsData.useVerticalStyle),
@@ -580,6 +585,11 @@ class EditSettingsScreen extends Component {
           value: settings.all.app.universalDarkMode,
           default: DEFAULT_APP_SETTINGS.universalDarkMode,
         },
+        splitMode: {
+          label: intl.formatMessage(messages.splitMode),
+          value: settings.all.app.splitMode,
+          default: DEFAULT_APP_SETTINGS.splitMode,
+        },
         serviceRibbonWidth: {
           label: intl.formatMessage(messages.serviceRibbonWidth),
           value: settings.all.app.serviceRibbonWidth,
@@ -684,6 +694,7 @@ class EditSettingsScreen extends Component {
           isAdaptableDarkModeEnabled={
             this.props.stores.settings.app.adaptableDarkMode
           }
+          isSplitModeEnabled={this.props.stores.settings.app.splitMode}
           isTodosActivated={this.props.stores.todos.isFeatureEnabledByUser}
           isUsingCustomTodoService={
             this.props.stores.todos.isUsingCustomTodoService

--- a/src/environment.js
+++ b/src/environment.js
@@ -136,6 +136,7 @@ export const DEFAULT_APP_SETTINGS = {
   enableSpellchecking: true,
   spellcheckerLanguage: 'en-us',
   darkMode: isMac && electronApi.nativeTheme.shouldUseDarkColors,
+  splitMode: false,
   locale: '',
   fallbackLocale: 'en-US',
   beta: false,

--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -191,10 +191,10 @@ export default class WorkspacesStore extends FeatureStore {
       this.isSwitchingWorkspace = false;
       this.nextWorkspace = null;
       if (this.stores.settings.app.splitMode) {
-        const serviceNames = this.getWorkspaceServices(workspace).map(service => service.name);
-        document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
-          wrapper.style.display = serviceNames.includes(wrapper.dataset.name) ? '' : 'none';
-        });
+        const serviceNames = new Set(this.getWorkspaceServices(workspace).map(service => service.name));
+        for (const wrapper of document.querySelectorAll('.services__webview-wrapper')) {
+          wrapper.style.display = serviceNames.has(wrapper.dataset.name) ? '' : 'none';
+        }
       }
     }, 1000);
   };
@@ -212,9 +212,9 @@ export default class WorkspacesStore extends FeatureStore {
     setTimeout(() => {
       this.isSwitchingWorkspace = false;
       if (this.stores.settings.app.splitMode) {
-        document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
+        for (const wrapper of document.querySelectorAll('.services__webview-wrapper')) {
           wrapper.style.display = '';
-        });
+        }
       }
     }, 1000);
   };

--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -190,10 +190,12 @@ export default class WorkspacesStore extends FeatureStore {
     setTimeout(() => {
       this.isSwitchingWorkspace = false;
       this.nextWorkspace = null;
-      const serviceNames = this.getWorkspaceServices(workspace).map(service => service.name);
-      document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
-        wrapper.style.display = serviceNames.includes(wrapper.dataset.name) ? '' : 'none';
-      });
+      if (this.stores.settings.app.splitMode) {
+        const serviceNames = this.getWorkspaceServices(workspace).map(service => service.name);
+        document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
+          wrapper.style.display = serviceNames.includes(wrapper.dataset.name) ? '' : 'none';
+        });
+      }
     }, 1000);
   };
 
@@ -209,9 +211,11 @@ export default class WorkspacesStore extends FeatureStore {
     // Indicate that we are done switching to the default workspace
     setTimeout(() => {
       this.isSwitchingWorkspace = false;
-      document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
-        wrapper.style.display = '';
-      });
+      if (this.stores.settings.app.splitMode) {
+        document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
+          wrapper.style.display = '';
+        });
+      }
     }, 1000);
   };
 

--- a/src/features/workspaces/store.js
+++ b/src/features/workspaces/store.js
@@ -190,6 +190,10 @@ export default class WorkspacesStore extends FeatureStore {
     setTimeout(() => {
       this.isSwitchingWorkspace = false;
       this.nextWorkspace = null;
+      const serviceNames = this.getWorkspaceServices(workspace).map(service => service.name);
+      document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
+        wrapper.style.display = serviceNames.includes(wrapper.dataset.name) ? '' : 'none';
+      });
     }, 1000);
   };
 
@@ -205,6 +209,9 @@ export default class WorkspacesStore extends FeatureStore {
     // Indicate that we are done switching to the default workspace
     setTimeout(() => {
       this.isSwitchingWorkspace = false;
+      document.querySelectorAll('.services__webview-wrapper').forEach(wrapper => {
+        wrapper.style.display = '';
+      });
     }, 1000);
   };
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -239,6 +239,7 @@
   "settings.app.form.showDisabledServices": "Display disabled services tabs",
   "settings.app.form.showDragArea": "Show draggable area on window",
   "settings.app.form.showMessagesBadgesWhenMuted": "Show unread message badge when notifications are disabled",
+  "settings.app.form.splitMode": "Enable Split View Mode",
   "settings.app.form.startMinimized": "Start minimized",
   "settings.app.form.universalDarkMode": "Enable universal Dark Mode",
   "settings.app.form.useTouchIdToUnlock": "Allow using TouchID to unlock Ferdi",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -239,6 +239,7 @@
   "settings.app.form.showDisabledServices": "Wyświetlaj karty wyłączonych usług",
   "settings.app.form.showDragArea": "Show draggable area on window",
   "settings.app.form.showMessagesBadgesWhenMuted": "Pokaż licznik nieprzeczytanych wiadomości gdy powiadomienia są wyłączone",
+  "settings.app.form.splitMode": "Włącz tryb podzielony",
   "settings.app.form.startMinimized": "Uruchom zminimalizowany",
   "settings.app.form.universalDarkMode": "Włącz uniwersalny tryb ciemny",
   "settings.app.form.useTouchIdToUnlock": "Allow using TouchID to unlock Ferdi",

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -671,6 +671,10 @@ export default class ServicesStore extends Store {
     if (service.webview) {
       service.webview.blur();
       service.webview.focus();
+
+      if (this.stores.settings.all.app.splitMode) {
+        document.querySelector('.services__webview-wrapper.is-active').scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
+      }
     }
   }
 

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -163,6 +163,13 @@ export default class ServicesStore extends Store {
     );
 
     reaction(
+      () => this.stores.settings.app.splitMode,
+      () => {
+        this._shareSettingsWithServiceProcess();
+      },
+    );
+
+    reaction(
       () => this.stores.settings.app.searchEngine,
       () => {
         this._shareSettingsWithServiceProcess();
@@ -664,6 +671,10 @@ export default class ServicesStore extends Store {
     if (service.webview) {
       service.webview.blur();
       service.webview.focus();
+
+      if (this.stores.settings.app.splitMode) {
+        document.querySelector('.services__webview-wrapper.is-active').scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
+      }
     }
   }
 

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -682,7 +682,11 @@ export default class ServicesStore extends Store {
         this._focusService({ serviceId: service.id });
         if (this.stores.settings.app.splitMode && !focusEvent) {
           setTimeout(() => {
-            document.querySelector('.services__webview-wrapper.is-active').scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
+            document.querySelector('.services__webview-wrapper.is-active').scrollIntoView({
+              behavior: 'smooth',
+              block: 'end',
+              inline: 'nearest',
+            });
           }, 10);
         }
       } else {

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -671,10 +671,6 @@ export default class ServicesStore extends Store {
     if (service.webview) {
       service.webview.blur();
       service.webview.focus();
-
-      if (this.stores.settings.all.app.splitMode) {
-        document.querySelector('.services__webview-wrapper.is-active').scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
-      }
     }
   }
 

--- a/src/stores/ServicesStore.js
+++ b/src/stores/ServicesStore.js
@@ -671,19 +671,20 @@ export default class ServicesStore extends Store {
     if (service.webview) {
       service.webview.blur();
       service.webview.focus();
-
-      if (this.stores.settings.app.splitMode) {
-        document.querySelector('.services__webview-wrapper.is-active').scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
-      }
     }
   }
 
-  @action _focusActiveService() {
+  @action _focusActiveService(focusEvent = null) {
     if (this.stores.user.isLoggedIn) {
       // TODO: add checks to not focus service when router path is /settings or /auth
       const service = this.active;
       if (service) {
         this._focusService({ serviceId: service.id });
+        if (this.stores.settings.app.splitMode && !focusEvent) {
+          setTimeout(() => {
+            document.querySelector('.services__webview-wrapper.is-active').scrollIntoView({behavior: 'smooth', block: 'end', inline: 'nearest'});
+          }, 10);
+        }
       } else {
         debug('No service is active');
       }

--- a/src/stores/UIStore.ts
+++ b/src/stores/UIStore.ts
@@ -87,7 +87,7 @@ export default class UIStore extends Store {
   }
 
   @computed get isSplitModeActive() {
-    return !!this.stores.settings.all.app.splitMode;
+    return this.stores.settings.app.splitMode;
   }
 
   @computed get theme() {

--- a/src/stores/UIStore.ts
+++ b/src/stores/UIStore.ts
@@ -51,6 +51,15 @@ export default class UIStore extends Store {
       },
       { fireImmediately: true },
     );
+    reaction(
+      () => (
+        this.isSplitModeActive
+      ),
+      () => {
+        this._setupModeInDOM();
+      },
+      { fireImmediately: true },
+    );
   }
 
   @computed get showMessageBadgesEvenWhenMuted() {
@@ -75,6 +84,10 @@ export default class UIStore extends Store {
       isWithoutAdaptableInDarkMode ||
       isInDarkMode
     );
+  }
+
+  @computed get isSplitModeActive() {
+    return !!this.stores.settings.all.app.splitMode;
   }
 
   @computed get theme() {
@@ -112,6 +125,16 @@ export default class UIStore extends Store {
       body?.classList.remove('theme__dark');
     } else {
       body?.classList.add('theme__dark');
+    }
+  }
+
+  _setupModeInDOM() {
+    const body = document.querySelector('body');
+
+    if (!this.isSplitModeActive) {
+      body.classList.remove('mode__split');
+    } else {
+      body.classList.add('mode__split');
     }
   }
 }

--- a/src/stores/UIStore.ts
+++ b/src/stores/UIStore.ts
@@ -52,9 +52,7 @@ export default class UIStore extends Store {
       { fireImmediately: true },
     );
     reaction(
-      () => (
-        this.isSplitModeActive
-      ),
+      () => this.isSplitModeActive,
       () => {
         this._setupModeInDOM();
       },
@@ -132,9 +130,9 @@ export default class UIStore extends Store {
     const body = document.querySelector('body');
 
     if (!this.isSplitModeActive) {
-      body.classList.remove('mode__split');
+      body?.classList.remove('mode__split');
     } else {
-      body.classList.add('mode__split');
+      body?.classList.add('mode__split');
     }
   }
 }

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -82,6 +82,10 @@ body.win32:not(.isFullScreen) .app .app__content {
   height: calc(100% - 28px);
 }
 
+.mode__split .app .app__service {
+  overflow-x: auto;
+}
+
 .app {
   .app__content {
     display: flex;

--- a/src/styles/services.scss
+++ b/src/styles/services.scss
@@ -18,6 +18,16 @@
   }
 }
 
+.mode__split .services {
+  display: flex;
+  overflow: visible;
+
+  .services__webview {
+    position: relative;
+    flex: 1 0 488px;
+  }
+}
+
 .services {
   background: #FFF;
   flex: 1;
@@ -71,7 +81,7 @@
   }
 
   .services__info-layer {
-    position: absolut;
+    position: absolute;
     z-index: 110;
   }
 

--- a/src/styles/services.scss
+++ b/src/styles/services.scss
@@ -24,7 +24,15 @@
 
   .services__webview {
     position: relative;
-    flex: 1 0 488px;
+    flex: 1 0 50%;
+
+    @media (min-width: 1280px) {
+      flex-basis: 33.33%;
+    }
+
+    @media (min-width: 2048px) {
+      flex-basis: 25%;
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
This patch adds a new setting _Enable Split View Mode_, which allows to browse web services side by side in columns.

#### Motivation and Context
This was requested in issue #893.

#### Screenshots
![Ferdi Split View](https://user-images.githubusercontent.com/384997/133105548-7124dd5b-d546-416c-92f5-9ad790526298.png)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdi to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
Initial version of Split View Mode
