### PR TITLE
fix: regression from intl upgrades

### DIFF
--- a/src/containers/auth/ChangeServerScreen.js
+++ b/src/containers/auth/ChangeServerScreen.js
@@ -43,3 +43,5 @@ ChangeServerScreen.wrappedComponent.propTypes = {
     router: PropTypes.instanceOf(RouterStore).isRequired,
   }).isRequired,
 };
+
+export default ChangeServerScreen;

--- a/src/containers/auth/ImportScreen.js
+++ b/src/containers/auth/ImportScreen.js
@@ -35,3 +35,5 @@ ImportScreen.wrappedComponent.propTypes = {
     router: PropTypes.instanceOf(RouterStore).isRequired,
   }).isRequired,
 };
+
+export default ImportScreen;

--- a/src/containers/auth/LockedScreen.js
+++ b/src/containers/auth/LockedScreen.js
@@ -85,3 +85,5 @@ LockedScreen.wrappedComponent.propTypes = {
     user: PropTypes.instanceOf(UserStore).isRequired,
   }).isRequired,
 };
+
+export default LockedScreen;

--- a/src/containers/auth/LoginScreen.js
+++ b/src/containers/auth/LoginScreen.js
@@ -40,3 +40,5 @@ LoginScreen.wrappedComponent.propTypes = {
     user: PropTypes.instanceOf(UserStore).isRequired,
   }).isRequired,
 };
+
+export default LoginScreen;

--- a/src/containers/auth/PasswordScreen.js
+++ b/src/containers/auth/PasswordScreen.js
@@ -30,3 +30,5 @@ PasswordScreen.wrappedComponent.propTypes = {
     user: PropTypes.instanceOf(UserStore).isRequired,
   }).isRequired,
 };
+
+export default PasswordScreen;

--- a/src/containers/settings/InviteScreen.js
+++ b/src/containers/settings/InviteScreen.js
@@ -40,3 +40,5 @@ InviteScreen.wrappedComponent.propTypes = {
     user: PropTypes.instanceOf(UserStore).isRequired,
   }).isRequired,
 };
+
+export default InviteScreen;


### PR DESCRIPTION
#### Description of Change
- readded missing export default to various screens

#### Motivation and Context
Due to replacing 50+ files with the intl upgrades, I missed to re-add some `export default Component`, which broke various screens.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally