### PR TITLE
fix: accent color customization regression

### DIFF
--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -27,8 +27,6 @@ function darkenAbsolute(originalColor, absoluteChange) {
 }
 
 function generateAccentStyle(accentColorStr) {
-  let style = '';
-
   let accentColor = color(DEFAULT_APP_SETTINGS.accentColor);
   try {
     accentColor = color(accentColorStr);
@@ -36,7 +34,47 @@ function generateAccentStyle(accentColorStr) {
     // Ignore invalid accent color.
   }
   const darkerColorStr = darkenAbsolute(accentColor, 5).hex();
-  style += `
+  return `
+    .theme__dark .app .sidebar .sidebar__button.is-muted,
+    .theme__dark .app .sidebar .sidebar__button.is-active,
+    .sidebar .sidebar__button.is-muted, .sidebar .sidebar__button.is-active,
+    .tab-item.is-active, .settings .account .invoices .invoices__action button,
+    .settings-navigation .settings-navigation__link.is-active .badge,
+    a.link,
+    button.link
+    .auth .welcome .button:hover
+    .auth .welcome .button__inverted
+    .franz-form .franz-form__radio.is-selected
+    .theme__dark .franz-form__button.franz-form__button--inverted
+    .franz-form__button.franz-form__button--inverted {
+      color: ${accentColorStr};
+    }
+
+    .theme__dark .app .sidebar .sidebar__button.is-muted
+    .theme__dark .app .sidebar .sidebar__button.is-active
+    .sidebar .sidebar__button.is-muted
+    .sidebar .sidebar__button.is-active
+    .tab-item.is-active
+    .settings .account .invoices .invoices__action button
+    .settings-navigation .settings-navigation__link.is-active .badge
+    a.link
+    button.link
+    .auth .welcome .button:hover
+    .auth .welcome .button__inverted
+    .franz-form .franz-form__radio.is-selected
+    .theme__dark .franz-form__button.franz-form__button--inverted
+    .franz-form__button.franz-form__button--inverted {
+      background: ${accentColorStr};
+    }
+
+    .settings .settings__header .separator {
+      border-right-color: ${accentColorStr};
+    }
+
+    .franz-form .franz-form__radio.is-selected {
+      border-color: ${accentColorStr};
+    }
+
     a.button:hover, button.button:hover {
       background: ${darkenAbsolute(accentColor, 10).hex()};
     }
@@ -65,8 +103,6 @@ function generateAccentStyle(accentColorStr) {
       background: ${accentColor.lighten(0.35).hex()};
     }
   `;
-
-  return style;
 }
 
 function generateServiceRibbonWidthStyle(widthStr, iconSizeStr, vertical) {


### PR DESCRIPTION
<!-- Thank you for your Pull Request. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Please start by naming your pull request properly for e.g. "Add Google Tasks to Todo providers". -->
<!-- Please keep in mind that any text inside "<!--" and "--\>" are comments from us and won't be visible in your bug report, so please don't put any text in them. -->

#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change

#1959 removed the `build-theme-info` script, which was broken, along with the `themeInfo.json` that we used to dynamically build CSS rules for accent color customization. This resulted in the accent color not getting applied to most of the UI.

Instead of trying to restore the build-theme-info functionality, this commit takes a much simpler approach by statically adding the required CSS rules to `src/features/appearance/index.ts`.

Since these rules are no longer automatically generated, we need to update them once some CSS styling is added with the accent color.

A longer term fix would be to use CSS variables instead, but that approach would not be supported by `@meetfranz/theme`.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdi to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
none
