### PR TITLE
security: do not expose electron API to services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Under the hood
 
 - Progressing towards converting the whole code base from JS to TS (#1959) 💖 @mhatvan
+- Fix accent color customization (#1963) (#1965) 💖 @kris7t
+- Improved context isolation for sandboxing services (#1964) 💖 @kris7t
 
 # [v5.6.3-nightly.4](https://github.com/getferdi/ferdi/compare/v5.6.3-nightly.3...v5.6.3-nightly.4) (2021-09-16)
 

--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -1,12 +1,14 @@
 import { ipcRenderer } from 'electron';
+import { BrowserWindow, desktopCapturer, getCurrentWebContents } from '@electron/remote';
 import { pathExistsSync, readFileSync, existsSync } from 'fs-extra';
 
 const debug = require('debug')('Ferdi:Plugin:RecipeWebview');
 
 class RecipeWebview {
-  constructor(badgeHandler, notificationsHandler) {
+  constructor(badgeHandler, notificationsHandler, sessionHandler) {
     this.badgeHandler = badgeHandler;
     this.notificationsHandler = notificationsHandler;
+    this.sessionHandler = sessionHandler;
 
     ipcRenderer.on('poll', () => {
       this.loopFunc();
@@ -22,6 +24,26 @@ class RecipeWebview {
   loopFunc = () => null;
 
   darkModeHandler = false;
+
+  // TODO Remove this once we implement a proper wrapper.
+  get ipcRenderer() {
+    return ipcRenderer;
+  }
+
+  // TODO Remove this once we implement a proper wrapper.
+  get desktopCapturer() {
+    return desktopCapturer;
+  }
+
+  // TODO Remove this once we implement a proper wrapper.
+  get BrowserWindow() {
+    return BrowserWindow;
+  }
+
+  // TODO Remove this once we implement a proper wrapper.
+  get getCurrentWebContents() {
+    return getCurrentWebContents;
+  }
 
   /**
    * Initialize the loop
@@ -112,6 +134,14 @@ class RecipeWebview {
     if (typeof fn === 'function') {
       fn();
     }
+  }
+
+  clearStorageData(storageLocations) {
+    this.sessionHandler.clearStorageData(storageLocations);
+  }
+
+  releaseServiceWorkers() {
+    this.sessionHandler.releaseServiceWorkers();
   }
 }
 

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -199,7 +199,11 @@ class RecipeController {
     // Delete module from cache
     delete require.cache[require.resolve(modulePath)];
     try {
-      this.recipe = new RecipeWebview(badgeHandler, notificationsHandler);
+      this.recipe = new RecipeWebview(
+        badgeHandler,
+        notificationsHandler,
+        sessionHandler,
+      );
       // eslint-disable-next-line import/no-dynamic-require
       require(modulePath)(this.recipe, { ...config, recipe });
       debug('Initialize Recipe', config, recipe);

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -1,7 +1,6 @@
 /* eslint-disable global-require */
 /* eslint-disable import/first */
-import { contextBridge, desktopCapturer, ipcRenderer } from 'electron';
-import { BrowserWindow, getCurrentWebContents } from '@electron/remote';
+import { contextBridge, ipcRenderer } from 'electron';
 import { join } from 'path';
 import { autorun, computed, observable } from 'mobx';
 import { pathExistsSync, readFileSync } from 'fs-extra';
@@ -109,15 +108,8 @@ contextBridge.exposeInMainWorld('ferdi', {
   safeParseInt: text => badgeHandler.safeParseInt(text),
   displayNotification: (title, options) =>
     notificationsHandler.displayNotification(title, options),
-  clearStorageData: storageLocations =>
-    sessionHandler.clearStorageData(storageLocations),
   releaseServiceWorkers: () => sessionHandler.releaseServiceWorkers(),
   getDisplayMediaSelector,
-  getCurrentWebContents,
-  BrowserWindow,
-  ipcRenderer,
-  // TODO: When the discord recipe is changed to use the screenshare.js, this can be removed
-  desktopCapturer,
 });
 
 ipcRenderer.sendToHost(


### PR DESCRIPTION
#### Pre-flight Checklist

- [x] I have read the [Contributing Guidelines](https://github.com/getferdi/ferdi/blob/develop/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [Code of Conduct](https://github.com/getferdi/ferdi/blob/develop/CODE_OF_CONDUCT.md) that this project adheres to.
- [x] I have searched the [issue tracker](https://github.com/getferdi/ferdi/issues) for a feature request that matches the one I want to file, without success.

#### Description of Change
Service code running the the main world should not have access to any electron API.

This still allows recipes from `webview.js` accessing these APIs through the `@electron/remote` module and/or the Ferdi object, but `webview-unsafe.js` and the untrusted code coming from the service will not have any access.

Currently, no recipe accesses these APIs in its `webview-unsafe.js`, so the change should not break any recipes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] My pull request is properly named
- [x] The changes respect the code style of the project (`npm run prepare-code`)
- [x] `npm test` passes
- [x] I tested/previewed my changes locally

#### Release Notes
<!-- Please add a one-line description for users of Ferdi to read in the release notes, or 'none' if no notes relevant to such users. Examples and help on special cases: https://github.com/electron/clerk/blob/master/README.md#examples -->
none