### PR TITLE
fix: accent color customization regression hotfix

### DIFF
--- a/src/features/appearance/index.ts
+++ b/src/features/appearance/index.ts
@@ -37,33 +37,43 @@ function generateAccentStyle(accentColorStr) {
   return `
     .theme__dark .app .sidebar .sidebar__button.is-muted,
     .theme__dark .app .sidebar .sidebar__button.is-active,
-    .sidebar .sidebar__button.is-muted, .sidebar .sidebar__button.is-active,
-    .tab-item.is-active, .settings .account .invoices .invoices__action button,
+    .sidebar .sidebar__button.is-muted,
+    .sidebar .sidebar__button.is-active,
+    .tab-item.is-active,
+    .settings .account .invoices .invoices__action button,
     .settings-navigation .settings-navigation__link.is-active .badge,
     a.link,
-    button.link
-    .auth .welcome .button:hover
-    .auth .welcome .button__inverted
-    .franz-form .franz-form__radio.is-selected
-    .theme__dark .franz-form__button.franz-form__button--inverted
+    button.link,
+    .auth .welcome .button:hover,
+    .auth .welcome .button__inverted,
+    .franz-form .franz-form__radio.is-selected,
+    .theme__dark .franz-form__button.franz-form__button--inverted,
     .franz-form__button.franz-form__button--inverted {
       color: ${accentColorStr};
     }
 
-    .theme__dark .app .sidebar .sidebar__button.is-muted
-    .theme__dark .app .sidebar .sidebar__button.is-active
-    .sidebar .sidebar__button.is-muted
-    .sidebar .sidebar__button.is-active
-    .tab-item.is-active
-    .settings .account .invoices .invoices__action button
-    .settings-navigation .settings-navigation__link.is-active .badge
-    a.link
-    button.link
-    .auth .welcome .button:hover
-    .auth .welcome .button__inverted
-    .franz-form .franz-form__radio.is-selected
-    .theme__dark .franz-form__button.franz-form__button--inverted
-    .franz-form__button.franz-form__button--inverted {
+    .settings .settings__header,
+    .settings .settings__close,
+    .settings-navigation .settings-navigation__link.is-active,
+    a.button,
+    button.button,
+    .auth,
+    .info-bar,
+    .info-bar.info-bar--primary,
+    .infobox.infobox--primary,
+    .theme__dark .badge.badge--primary,
+    .theme__dark,
+    .badge.badge--primary,
+    .content-tabs .content-tabs__tabs .content-tabs__item.is-active,
+    #electron-app-title-bar .toolbar-dropdown:not(.open) > .toolbar-button > button:hover,
+    #electron-app-title-bar .list-item.selected .menu-item,
+    #electron-app-title-bar .list-item.selected:focus .menu-item,
+    .theme__dark .quick-switch .active,
+    .franz-form .franz-form__toggle-wrapper .franz-form__toggle.is-active .franz-form__toggle-button,
+    .theme__dark .franz-form__button,
+    .franz-form__button,
+    .ferdi__fab,
+    .franz-form .franz-form__slider-wrapper .slider::-webkit-slider-thumb {
       background: ${accentColorStr};
     }
 


### PR DESCRIPTION
Sorry, something got mucked up when converting the old `themeInfo.json` to static CSS last time. This time, it should be correct.