### PR TITLE
security: do not expose electron API to services, part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # [v5.6.3-nightly.7](https://github.com/getferdi/ferdi/compare/v5.6.3-nightly.4...v5.6.3-nightly.7) (2021-09-19)
 
+### Bug fixes
+
+- Fix loading team icon in Slack (getferdi/recipes#713) 💖 @kris7t
+
 ### Under the hood
 
 - Progressing towards converting the whole code base from JS to TS (#1959) 💖 @mhatvan
 - Fix accent color customization (#1963) (#1965) 💖 @kris7t
-- Improved context isolation for sandboxing services (#1964) 💖 @kris7t
+- Improved context isolation for sandboxing services (#1964) (#1966) 💖 @kris7t
 
 # [v5.6.3-nightly.4](https://github.com/getferdi/ferdi/compare/v5.6.3-nightly.3...v5.6.3-nightly.4) (2021-09-16)
 

--- a/src/webview/lib/RecipeWebview.js
+++ b/src/webview/lib/RecipeWebview.js
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import { BrowserWindow, desktopCapturer, getCurrentWebContents } from '@electron/remote';
+import { BrowserWindow } from '@electron/remote';
 import { pathExistsSync, readFileSync, existsSync } from 'fs-extra';
 
 const debug = require('debug')('Ferdi:Plugin:RecipeWebview');
@@ -31,18 +31,8 @@ class RecipeWebview {
   }
 
   // TODO Remove this once we implement a proper wrapper.
-  get desktopCapturer() {
-    return desktopCapturer;
-  }
-
-  // TODO Remove this once we implement a proper wrapper.
   get BrowserWindow() {
     return BrowserWindow;
-  }
-
-  // TODO Remove this once we implement a proper wrapper.
-  get getCurrentWebContents() {
-    return getCurrentWebContents;
   }
 
   /**

--- a/src/webview/recipe.js
+++ b/src/webview/recipe.js
@@ -108,7 +108,6 @@ contextBridge.exposeInMainWorld('ferdi', {
   safeParseInt: text => badgeHandler.safeParseInt(text),
   displayNotification: (title, options) =>
     notificationsHandler.displayNotification(title, options),
-  releaseServiceWorkers: () => sessionHandler.releaseServiceWorkers(),
   getDisplayMediaSelector,
 });
 


### PR DESCRIPTION
After refactoring some recipes in https://github.com/getferdi/ferdi/pull/1964, we no longer need to expose some APIs to recipes.