### PR TITLE
shortcuts for toggling service

### DIFF
--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -10,7 +10,7 @@ import ms from 'ms';
 
 import { observable, autorun, reaction } from 'mobx';
 import ServiceModel from '../../../models/Service';
-import { cmdOrCtrlShortcutKey } from '../../../environment';
+import { cmdOrCtrlShortcutKey, toggleServiceFeaturesShortcutKey } from '../../../environment';
 import globalMessages from '../../../i18n/globalMessages';
 import SettingsStore from '../../../stores/SettingsStore';
 
@@ -251,28 +251,28 @@ class TabItem extends Component {
           ? intl.formatMessage(messages.disableNotifications)
           : intl.formatMessage(messages.enableNotifications),
         click: () => toggleNotifications(),
-        accelerator: `${cmdOrCtrlShortcutKey()}+N`,
+        accelerator: `${toggleServiceFeaturesShortcutKey()}+N`,
       },
       {
         label: service.isMuted
           ? intl.formatMessage(messages.enableAudio)
           : intl.formatMessage(messages.disableAudio),
         click: () => toggleAudio(),
-        accelerator: `${cmdOrCtrlShortcutKey()}+A`,
+        accelerator: `${toggleServiceFeaturesShortcutKey()}+A`,
       },
       {
         label: service.isDarkModeEnabled
           ? intl.formatMessage(messages.disableDarkMode)
           : intl.formatMessage(messages.enableDarkMode),
         click: () => toggleDarkMode(),
-        accelerator: `${cmdOrCtrlShortcutKey()}+D`,
+        accelerator: `${toggleServiceFeaturesShortcutKey()}+D`,
       },
       {
         label: intl.formatMessage(
           service.isEnabled ? messages.disableService : messages.enableService,
         ),
         click: () => (service.isEnabled ? disableService() : enableService()),
-        accelerator: `${cmdOrCtrlShortcutKey()}+S`,
+        accelerator: `${toggleServiceFeaturesShortcutKey()}+S`,
       },
       {
         label: intl.formatMessage(

--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -10,7 +10,7 @@ import ms from 'ms';
 
 import { observable, autorun, reaction } from 'mobx';
 import ServiceModel from '../../../models/Service';
-import { cmdOrCtrlShortcutKey, toggleServiceFeaturesShortcutKey } from '../../../environment';
+import { cmdOrCtrlShortcutKey, shiftKey, altKey } from '../../../environment';
 import globalMessages from '../../../i18n/globalMessages';
 import SettingsStore from '../../../stores/SettingsStore';
 
@@ -251,28 +251,28 @@ class TabItem extends Component {
           ? intl.formatMessage(messages.disableNotifications)
           : intl.formatMessage(messages.enableNotifications),
         click: () => toggleNotifications(),
-        accelerator: `${toggleServiceFeaturesShortcutKey()}+N`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${altKey()}+N`,
       },
       {
         label: service.isMuted
           ? intl.formatMessage(messages.enableAudio)
           : intl.formatMessage(messages.disableAudio),
         click: () => toggleAudio(),
-        accelerator: `${toggleServiceFeaturesShortcutKey()}+A`,
+        accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+A`,
       },
       {
         label: service.isDarkModeEnabled
           ? intl.formatMessage(messages.disableDarkMode)
           : intl.formatMessage(messages.enableDarkMode),
         click: () => toggleDarkMode(),
-        accelerator: `${toggleServiceFeaturesShortcutKey()}+D`,
+        accelerator: `${shiftKey()}+${altKey()}+D`,
       },
       {
         label: intl.formatMessage(
           service.isEnabled ? messages.disableService : messages.enableService,
         ),
         click: () => (service.isEnabled ? disableService() : enableService()),
-        accelerator: `${toggleServiceFeaturesShortcutKey()}+S`,
+       accelerator: `${cmdOrCtrlShortcutKey()}+${shiftKey()}+S`,
       },
       {
         label: intl.formatMessage(

--- a/src/components/services/tabs/TabItem.js
+++ b/src/components/services/tabs/TabItem.js
@@ -251,24 +251,28 @@ class TabItem extends Component {
           ? intl.formatMessage(messages.disableNotifications)
           : intl.formatMessage(messages.enableNotifications),
         click: () => toggleNotifications(),
+        accelerator: `${cmdOrCtrlShortcutKey()}+N`,
       },
       {
         label: service.isMuted
           ? intl.formatMessage(messages.enableAudio)
           : intl.formatMessage(messages.disableAudio),
         click: () => toggleAudio(),
+        accelerator: `${cmdOrCtrlShortcutKey()}+A`,
       },
       {
         label: service.isDarkModeEnabled
           ? intl.formatMessage(messages.disableDarkMode)
           : intl.formatMessage(messages.enableDarkMode),
         click: () => toggleDarkMode(),
+        accelerator: `${cmdOrCtrlShortcutKey()}+D`,
       },
       {
         label: intl.formatMessage(
           service.isEnabled ? messages.disableService : messages.enableService,
         ),
         click: () => (service.isEnabled ? disableService() : enableService()),
+        accelerator: `${cmdOrCtrlShortcutKey()}+S`,
       },
       {
         label: intl.formatMessage(

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -39,5 +39,3 @@ export const addNewServiceShortcutKey = (isAccelerator = true) =>
   `${cmdOrCtrlShortcutKey(isAccelerator)}+N`;
 export const settingsShortcutKey = (isAccelerator = true) =>
   `${cmdOrCtrlShortcutKey(isAccelerator)}+${isMac ? ',' : 'P'}`;
-export const toggleServiceFeaturesShortcutKey = (isAccelerator = true) =>
-  `${cmdOrCtrlShortcutKey(isAccelerator)}+${shiftKey(isAccelerator)}`;

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -39,3 +39,5 @@ export const addNewServiceShortcutKey = (isAccelerator = true) =>
   `${cmdOrCtrlShortcutKey(isAccelerator)}+N`;
 export const settingsShortcutKey = (isAccelerator = true) =>
   `${cmdOrCtrlShortcutKey(isAccelerator)}+${isMac ? ',' : 'P'}`;
+export const toggleServiceFeaturesShortcutKey = (isAccelerator = true) =>
+  `${cmdOrCtrlShortcutKey(isAccelerator)}+${shiftKey(isAccelerator)}`;


### PR DESCRIPTION

**Description of Change**
Added shortcuts for toggling the service features
Disable notifications
Disable audio
Disable dark mode
Disable service

**Motivation and Context**
#1636 

**Screenshots**
<img width="203" alt="Screenshot 2021-10-30 at 11 57 58 PM" src="https://user-images.githubusercontent.com/66486870/139555195-165af4e0-436b-4e0c-b961-6e10daae02aa.png">

Dark mode enabled with shortcut :
<img width="1163" alt="Screenshot 2021-10-30 at 11 59 01 PM" src="https://user-images.githubusercontent.com/66486870/139555223-39b85ebc-73cb-4774-b4f8-62166ee1d01b.png">

Service Disabled with shortcut
<img width="1235" alt="Screenshot 2021-10-30 at 11 59 20 PM" src="https://user-images.githubusercontent.com/66486870/139555238-16adab7b-6a61-42bb-808e-846f1dcc6073.png">


 **Checklist**

- [x] My pull request is properly named
- [x] The changes respect the code style of the project (npm run prepare-code)
- [x] npm test passes
- [x]  I tested/previewed my changes locally




